### PR TITLE
Add 11 ONNX reconstruction scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 
 #### Issue Tracking
 
-* All enhancement, bugfix, or change requests must begin with the creation of a [DLA SW Issue Request](https://github.com/nvidia/).
+* All enhancement, bugfix, or change requests must begin with the creation of a [DLA SW Issue Request](https://github.com/NVIDIA/Deep-Learning-Accelerator-SW).
   * The issue request must be reviewed by TensorRT engineers and approved prior to code review.
 
 
@@ -74,18 +74,19 @@
 
 
 #### Pull Requests
+
 Developer workflow for code contributions is as follows:
 
 1. Developers must first [fork](https://help.github.com/en/articles/fork-a-repo) the [upstream](https://github.com/nvidia/TensorRT) TensorRT OSS repository.
 
 2. Git clone the forked repository and push changes to the personal fork.
 
-  ```bash
+```bash
 git clone https://github.com/YOUR_USERNAME/YOUR_FORK.git TensorRT
 # Checkout the targeted branch and commit changes
 # Push the commits to a branch on the fork (remote).
 git push -u origin <local-branch>:<remote-branch>
-  ```
+```
 
 3. Once the code changes are staged on the fork and ready for review, a [Pull Request](https://help.github.com/en/articles/about-pull-requests) (PR) can be [requested](https://help.github.com/en/articles/creating-a-pull-request) to merge the changes from a branch of the fork into a selected branch of upstream.
   * Exercise caution when selecting the source and target branches for the PR.
@@ -95,7 +96,6 @@ git push -u origin <local-branch>:<remote-branch>
   * While under review, mark your PRs as work-in-progress by prefixing the PR title with [WIP].
 
 4. Since there is no CI/CD process in place yet, the PR will be accepted and the corresponding issue closed only after adequate testing has been completed, manually, by the developer and/or TensorRT engineer reviewing the code.
-
 
 #### Signing Your Work
 

--- a/FAQ/README.md
+++ b/FAQ/README.md
@@ -8,9 +8,9 @@
 - [What kind of overhead exists when you deploy a network with layers alternating between GPU and DLA?](#what-kind-of-overhead-exists-when-you-deploy-a-network-with-layers-alternating-between-gpu-and-dla-)
 - [Why is the latency higher when running workloads on two DLA cores and GPU?](#why-is-the-latency-higher-when-running-workloads-on-two-dla-cores-and-gpu-)
 - [What precision formats are supported on DLA?](#what-precision-formats-are-supported-on-dla-)
-- [How does FP16 performance compare to int8?](#how-does-fp16-performance-compare-to-int8-)
+- [How does FP16 performance compare to INT8?](#how-does-fp16-performance-compare-to-int8-)
 - [How do you quantize the network to INT8 for DLA?](#how-do-you-quantize-the-network-to-int8-for-dla-)
-- [Is a calibration file always necessary to convert a model to int8?](#is-a-calibration-file-always-necessary-to-convert-a-model-to-int8-)
+- [Is a calibration file always necessary to convert a model to INT8?](#is-a-calibration-file-always-necessary-to-convert-a-model-to-int8-)
 - [Is ONNX the recommended way to go from PyTorch to TensorRT?](#is-onnx-the-recommended-way-to-go-from-pytorch-to-tensorrt-)
 - [What's the difference between Dense TOPs and Sparse TOPS?](#what-s-the-difference-between-dense-tops-and-sparse-tops-)
 - [Can we scale the clock frequency on DLA?](#can-we-scale-the-clock-frequency-on-dla-)
@@ -22,10 +22,6 @@
 - [What tools and utilities are available for profiling and debugging DLA workloads?](#what-tools-and-utilities-are-available-for-profiling-and-debugging-dla-workloads-)
 - [Will DLA help in reducing power consumption?](#will-dla-help-in-reducing-power-consumption-)
 - [Where can we learn more about how DLA is leveraged in ISAAC reference applications?](#where-can-we-learn-more-about-how-dla-is-leveraged-in-isaac-reference-applications-)
-
-
-
-
 
 ### Which NVIDIA Jetson or DRIVE Modules have DLA?
 All Jetson AGX Orin & Orin NX boards, and all prior generation Jetson AGX Xavier & Xavier NX modules have DLA Cores. [This](https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/SD/PlatformPowerAndPerformance/JetsonOrinNxSeriesAndJetsonAgxOrinSeries.html#supported-modes-and-power-efficiency) is a very handy reference for all platforms with at least one DLA instance and their corresponding clock settings. DRIVE Xavier and DRIVE Orin also have DLA Cores.
@@ -44,44 +40,46 @@ DLA supports Convolution and Transposed Convolution. With a few tweaks in the pa
 Re-expressing operations not currently supported on DLA in terms of [supported operations](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla_layers) is a common technique that you can use to run your entire network on DLA.
 
 ### What kind of overhead exists when you deploy a network with layers alternating between GPU and DLA?
-There can be overhead due to couple of common reasons:
-Reformatting of the tensors between GPU and DLA memory formats as of today. The kCHW16 (FP16), and kCHW32 (INT8) formats are common on DLA & GPU; however, the default formats are not the same. So ensure that you use commonly supported tensor formats to avoid the reformatting overhead. See [here](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#restrictions-with-dla) for more details.
-Overhead due to small workloads. Ensure you have a network where subgraphs (a contiguous portion of the network graph) maps to DLA rather than individual layers going back and forth between GPU and DLA.
+There can be overhead due to a couple of reasons:
+* Reformatting of the tensors between GPU and DLA memory formats. The kCHW16 (FP16), and kCHW32 (INT8) formats are common on DLA & GPU; however, the default formats are not the same. So ensure that you use commonly supported tensor formats to avoid the reformatting overhead. See [here](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#restrictions-with-dla) for more details.
+* Overhead due to small workloads. Ensure you have a network where subgraphs (a contiguous portion of the network graph) maps to DLA, rather than individual layers going back and forth between GPU and DLA.
 
 
 ### Why is the latency higher when running workloads on two DLA cores and GPU?
 There can be several reasons for this, let’s focus on the three most common ones: 
 
-1) DLA and GPU both consume the same resource: System DRAM. The more bandwidth-bound a workload is, the higher the chances that both DLA and GPU will become bottlenecked for memory access when running in parallel.
+1) DLA and GPU both consume the same resource: system DRAM. The more bandwidth-bound a workload is, the higher the chances that both DLA and GPU will become bottlenecked for memory access when running in parallel.
 2) If you do not run DLA with native DLA formats through TensorRT, there will be GPU reformat kernels inserted around every DLA inference. This means you have added additional GPU workload (since the GPU is busy with reformatting). To reduce this, you can use the [reformat-free I/O options](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#reformat-free-network-tensors) for DLA.
-3) Interference due to inefficient scheduling can also be a reason: Especially at low batch sizes and in those scenarios when input frames arrive one after another at a fixed rate, the DLA task does not get scheduled quickly or does not register the completion signal back to the GPU quickly enough. This happens both for single-context cases as well as multi-contexts cases. Known options for reducing this type of interference:
-Using [cuDLA for DLA inference](https://www.nvidia.com/en-us/on-demand/session/gtcspring22-s41516/): See [here](https://github.com/NVIDIA/cuda-samples/tree/master/Samples/4_CUDA_Libraries/cuDLAStandaloneMode) for a sample in standalone mode (without TensorRT – requires extracting a DLA loadable from a TensorRT engine). Starting from TensorRT 8.5, DLA inference through the TensorRT interface uses cuDLA by default.
-Increasing [the preferred number of compute and copy engine concurrent connections](https://docs.nvidia.com/deploy/mps/index.html#topic_5_2_4) (work queues): Can be achieved by setting the Linux environment variable `CUDA_DEVICE_MAX_CONNECTIONS=32`.
+3) Interference due to inefficient scheduling can also be a reason: especially at low batch sizes and in those scenarios when input frames arrive one after another at a fixed rate, the DLA task does not get scheduled quickly or does not register the completion signal back to the GPU quickly enough. This happens both for single-context cases as well as multi-context cases. Known options for reducing this type of interference:
+  * Using [cuDLA for DLA inference](https://www.nvidia.com/en-us/on-demand/session/gtcspring22-s41516/): see [here](https://github.com/NVIDIA/cuda-samples/tree/master/Samples/4_CUDA_Libraries/cuDLAStandaloneMode) for a sample in standalone mode (without TensorRT – requires extracting a DLA loadable from a TensorRT engine). Starting from TensorRT 8.5, DLA inference through the TensorRT interface uses cuDLA by default.
+  * Increasing [the preferred number of compute and copy engine concurrent connections](https://docs.nvidia.com/deploy/mps/index.html#topic_5_2_4) (work queues): can be achieved by setting the Linux environment variable `CUDA_DEVICE_MAX_CONNECTIONS=32`.
 
 ### What precision formats are supported on DLA?
 DLA on Orin and Xavier supports the optimal inference precision formats - FP16 and INT8.
 DLA on Orin specifically has been optimized for INT8 given the optimality of this precision for AI inference by trading off FP16 performance when compared to DLA on Xavier. 
 The option of FP16 and INT8 hybrid precision in the same model allows you to find the sweet spot between accuracy and low resource consumption.
 
-### How does FP16 performance compare to int8?
+### How does FP16 performance compare to INT8?
 NVIDIA has designed its Deep Learning Accelerator with an emphasis on INT8 for AI inferencing since inference is the key value proposition of the Jetson or DRIVE modules. Training happens on bigger NVIDIA GPUs and systems. 
 Orin DLA was designed for 9x increase in INT8 compute and higher power efficiency in exchange for lower FP16 convolution compute, compared to previous generation Xavier architecture. DLA is designed for well-understood AI inference models and running at a lower power and lower area overhead. As a result, it offers a highly optimized INT8 DL inference engine.
 
 ### How do you quantize the network to INT8 for DLA?
 To quantize a network for DLA, you need to know the dynamic range of the intermediate tensors to help map FP32/FP16 (wide representation) to INT8 (narrow representation). For DLA, this can be achieved through TensorRT’s Post-Training Quantization (PTQ) toolchain.
-The TensorRT PTQ workflow utilizes a representative calibration dataset after a model has been trained. This provides the scaling factors for the output and input tensors of layers that you want to run in int8. If you do not have scaling factors, those layers are run in fp16.
+The TensorRT PTQ workflow utilizes a representative calibration dataset after a model has been trained. This provides the scaling factors for the output and input tensors of layers that you want to run in INT8. If you do not have scaling factors, those layers are run in FP16.
 Here is a sample you can reference to get started: https://github.com/NVIDIA/TensorRT/tree/main/samples/sampleINT8 
 Note the presence of the `--useDLACore=N` option.
 
-### Is a calibration file always necessary to convert a model to int8?
-You can either use a TensorRT calibration file or use the [ITensor TensorRT APIs](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_tensor.html#a04d2107c0a3a5058d485863339f45872) to set a network tensor’s scaling factors. If you do not have scaling factors for individual tensors, you can also run the affected layers in fp16 precision.
+### Is a calibration file always necessary to convert a model to INT8?
+You can either use a TensorRT calibration file or use the [ITensor TensorRT APIs](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_tensor.html#a04d2107c0a3a5058d485863339f45872) to set a network tensor’s scaling factors. If you do not have scaling factors for individual tensors, you can also run the affected layers in FP16 precision.
 
-How would I go about using DLA without TensorRT?
+### How would I go about using DLA without TensorRT?
 TensorRT Builder is the only user interface to invoke the DLA compiler and it provides a consistent interface to parse your network and build an inference engine both for GPU as well as DLA (DLA loadable). 
-TensorRT Runtime provides the runtime APIs to invoke the DLA Runtime stack with little user intervention but for advanced users, you can also cuDLA runtime APIs to run your DLA loadable on DLA HW.
+TensorRT Runtime provides the runtime APIs to invoke the DLA Runtime stack with little user intervention.
+Advanced users can also use cuDLA runtime API to run your DLA loadable on DLA HW.
 
 ### Is ONNX the recommended way to go from PyTorch to TensorRT?
-DLA depends on TensorRT for parsing the network before the DLA compiler compiles it into a loadable. ONNX is the preferred TensorRT path to go from various frameworks including Pytorch to TRT as of today. However, you can also use [Torch-TensorRT](https://github.com/pytorch/TensorRT/blob/d9baa3668a9f2c4a1447c53c3a686e1b316613b8/docs/v0.3.0/_sources/tutorials/using_dla.rst.txt) with DLA for example as well as building your own translator using TensorRT’s API.
+DLA depends on TensorRT for parsing the network before the DLA compiler compiles it into a loadable. ONNX is the preferred TensorRT path to go from various frameworks including Pytorch to TRT as of today. However, you can also use [Torch-TensorRT](https://github.com/pytorch/TensorRT/blob/d9baa3668a9f2c4a1447c53c3a686e1b316613b8/docs/v0.3.0/_sources/tutorials/using_dla.rst.txt) with DLA for example.
+You could also build your own translator using TensorRT’s API.
 
 ### What's the difference between Dense TOPs and Sparse TOPS?
 Structured Sparsity is an optimization to leverage a certain pattern in the sparse computation within a network because of zero weights. Structured sparsity is a new feature of the Ampere GPU and the DLAs in Orin. It allows you to increase your compute throughput by providing convolution weights with 2:4 “sparse” weight patterns. This means that for a KCRS convolution weight blob, for every 4 weights along the C dimension, at least 2 are zeros. For DLA, you will need C > 64 in order to enable structured sparsity. Refer to this [detailed article on how structured sparsity is leveraged](https://developer.nvidia.com/blog/accelerating-inference-with-sparsity-using-ampere-and-tensorrt/) both in HW and SW on NVIDIA platforms.
@@ -93,12 +91,13 @@ Yes, you can set the clock frequency on DLA. The [reference here](https://docs.n
 Yes, it is connected to system DRAM, just like GPU or CPU.
 
 ### How much internal SRAM does the DLA have? 
-On Xavier, 2 DLAs and 2 Programmable Vision Accelerators (PVAs) share a total of 4 Megabyte of SRAM. On Orin, each DLA has exclusive access to 1 Megabyte of internal SRAM.
+On Xavier, 2 DLAs and 2 Programmable Vision Accelerators (PVAs) share a total of 4 MiB of SRAM.
+On Orin, each DLA has exclusive access to 1 MiB of internal SRAM.
 
 ### How does the inference latency on DLA compare to that of GPU?
 Latency for a single workload on one DLA will be higher when compared to GPU because each DLA instance has lower theoretical math throughput (TOPs) than the GPU. There are 2 DLAs on Xavier and Orin, and at default clocks, each DLA instance has lower theoretical math throughput (TOPs) than the GPU. 
 
-However, when you look at it from an application perspective, you can reduce your total or overall latency by distributing the deep learning and non-deep learning workloads across DLA & GPU. For certain applications where there are requirements on consistency of workload latency, DLA is especially suited.
+However, when you look at it from an application perspective, you can reduce your total or overall latency by distributing the deep learning and non-deep learning workloads across DLA & GPU. DLA is especially suitable for applications where there are requirements on consistency of workload latency.
 
 If you want to evaluate device performance for a certain workload, we recommend starting with the calculation of math utilization for GPU and DLA. The math utilization is calculated by dividing the achieved throughput (number of images per second times FLOPs per image) by the theoretical peak throughput of the accelerator at the used precision (number of operations per second, often indicated in Tera operations per seconds or TOPs).
 
@@ -118,10 +117,10 @@ The easiest way to measure DLA performance is using [trtexec](https://github.com
 Add `--allowGPUFallback` if model cannot fully run on DLA
 
 Nsight System is the best tool to profile your application not just for DLA but for the entire SoC. You can get a detailed profile of DLA runtime of each subgraph and which core is used during runtime and we continue to add more profiling functionality into Nsight systems. See [here](https://developer.nvidia.com/docs/drive/drive-os/latest/tensorrt/developer-guide/index.html#dla-profiling) for more details.
-For (layer-wise) debugging for accuracy, it is recommended to use tools like [Polygraphy](https://github.com/NVIDIA/TensorRT/tree/master/tools/Polygraphy).
+For (layer-wise) debugging for accuracy, it is recommended to use tools like [TensorRT Polygraphy](https://github.com/NVIDIA/TensorRT/tree/master/tools/Polygraphy).
 
 ### Will DLA help in reducing power consumption?
-Yes, DLA is optimized for high performance per Watt. If you want to reduce the power consumption of your Jetson or DRIVE Module, the best approach is to map as much of your deep learning workload to the DLA as possible.
+Yes, DLA is optimized for high performance per watt. If you want to reduce the power consumption of your Jetson or DRIVE Module, the best approach is to map as much of your deep learning workload to the DLA as possible.
 
 ### Where can we learn more about how DLA is leveraged in ISAAC reference applications?
 ISAAC SDK has a reference application for proximity segmentation using stereo data. The application has a requirement of having two independent paths and the team designed the independent pipelines to leverage both GPU and DLA optimally. You can find the code and their network architecture in the link here: https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_proximity_segmentation

--- a/README.md
+++ b/README.md
@@ -17,18 +17,18 @@ Classification|[ResNet-50](https://github.com/mlcommons/inference_results_v2.1/t
 Object Detection|[SSD-ResNet-34](https://github.com/mlcommons/inference_results_v2.0/tree/master/closed/NVIDIA/results/Orin_TRT/ssd-resnet34/Offline/accuracy)|mAP COCO 2017*: 0.21<br>(GPU INT8: 0.21, [FP32 reference 0.20](https://github.com/mlcommons/inference/tree/master/vision/classification_and_detection))|NMS (Last node of the network)|See [SSD-ResNet-34](scripts/prepare_models/README.md/#ssd-resnet-34) section in `scripts/prepare_models/README.md`
 Object Detection|[SSD-MobileNetV1](https://github.com/mlcommons/inference_results_v2.0/tree/master/closed/NVIDIA/results/Orin_TRT/ssd-mobilenet/Offline/accuracy)|mAP COCO 2017*: 0.23<br>(GPU INT8: 0.23, [FP32 reference: 0.23](https://github.com/mlcommons/inference/blob/f301a4bdbd1d4bf6781a8925a3bd3967f9855458/README.md))|NMS (Last node of the network)|See [SSD-MobileNetV1](scripts/prepare_models/README.md/#ssd-mobilenetv1) section in `scripts/prepare_models/README.md`
 
-**Accuracy measured internally by NVIDIA, there may be slight differences compared to previous MLPerf submissions.*
+**Accuracy measured internally by NVIDIA, there may be slight differences compared to previous MLPerf Inference submissions.*
 
 Key takeaways:
 - Networks tend to have common network backbones and some variation at the end. You can run the compute-intensive backbones on DLA and final layers for post-processing on the GPU.
 - GPU and DLA are not bitwise accurate. So the difference in the math is expected and the difference would be within a certain acceptable % of the FP32 reference.
 
 More resources:
-- MLPerf 2.1 (Orin DLA): https://mlcommons.org/en/inference-edge-21/
-- MLPerf 2.0 (Xavier & Orin DLA): https://mlcommons.org/en/inference-edge-20/
+- MLPerf Inference 2.1 (Orin DLA): https://mlcommons.org/en/inference-edge-21/
+- MLPerf Inference 2.0 (Xavier & Orin DLA): https://mlcommons.org/en/inference-edge-20/
 
 ## Setup
-Install the Python depencencies with:
+Install the Python dependencies with:
 ```bash
 python3 -m pip install requirements.txt
 ```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ NVIDIA DLA hardware is a fixed-function accelerator engine targeted for deep lea
 
 DLA software consists of the DLA compiler and the DLA runtime stack. The offline compiler translates the neural network graph into a DLA loadable binary and can be invoked using NVIDIA TensorRT™, NvMedia-DLA or cuDLA. The runtime stack consists of the DLA firmware, kernel mode driver, and user mode driver.
 
+Reference for more details: [DLA product page](https://developer.nvidia.com/deep-learning-accelerator)
+
 
 ## DLA Reference Models
 
@@ -26,6 +28,11 @@ Key takeaways:
 More resources:
 - MLPerf Inference 2.1 (Orin DLA): https://mlcommons.org/en/inference-edge-21/
 - MLPerf Inference 2.0 (Xavier & Orin DLA): https://mlcommons.org/en/inference-edge-20/
+
+## ONNX operators supported on DLA
+
+See [operators/README.md](operators/README.md) for details on ONNX operators already supported on DLA and planned to be supported in future releases.
+
 
 ## Setup
 Install the Python dependencies with:

--- a/operators/README.md
+++ b/operators/README.md
@@ -3,7 +3,7 @@
 # Supported ONNX Operators on Orin DLA
 
 DLA operator functionality is exposed through the TensorRT builder, which internally links to DLA SW libraries (see [DLA Workflow](https://developer.nvidia.com/deep-learning-accelerator)). While some operators may already be available in DLA SW, TensorRT may not expose them yet.
-See below for the support matrix of ONNX operators on Orin DLA. If you are interested in a specific DLA operator that is not supported through TensoRT yet, feel free to raise an [GitHub Issue](https://github.com/NVIDIA/Deep-Learning-Accelerator-SW/issues) and/or inform your NVIDIA represenative (in particular for NVIDIA DRIVE customers).
+See below for the support matrix of ONNX operators on Orin DLA. If you are interested in a specific DLA operator that is not supported through TensorRT yet, feel free to raise a [GitHub Issue](https://github.com/NVIDIA/Deep-Learning-Accelerator-SW/issues) and/or inform your NVIDIA representative (in particular for NVIDIA DRIVE customers).
 
 See [General Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest) that apply to all operators. Many of those operators are supported on Xavier DLA as well, see [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest).
 

--- a/operators/README.md
+++ b/operators/README.md
@@ -1,0 +1,95 @@
+<!--- SPDX-License-Identifier: Apache-2.0 -->
+
+# Supported ONNX Operators on Orin DLA
+
+DLA operator functionality is exposed through the TensorRT builder, which internally links to DLA SW libraries (see [DLA Workflow](https://developer.nvidia.com/deep-learning-accelerator)). While some operators may already be available in DLA SW, TensorRT may not expose them yet.
+See below for the support matrix of ONNX operators on Orin DLA. If you are interested in a specific DLA operator that is not supported through TensoRT yet, feel free to raise an [GitHub Issue](https://github.com/NVIDIA/Deep-Learning-Accelerator-SW/issues) and/or inform your NVIDIA represenative (in particular for NVIDIA DRIVE customers).
+
+See [General Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest) that apply to all operators. Many of those operators are supported on Xavier DLA as well, see [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest).
+
+TensorRT 8.5 supports operators up to Opset 17. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/master/docs/Operators.md).
+
+## Operator Support Matrix
+
+| Operator                  | Orin DLA support through TensorRT | Orin DLA support through DLA SW   | Restrictions                                                                                                           |
+|---------------------------|--------------------------|--------------------------|------------------------------------------------------------------------------------------------------------------------|
+| Abs                       | Native                   | Native | See **Unary layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| Acos                      | None                   | Planned in future release |
+| Acosh                     | None          | Planned in future release  |
+| Add                       | Native                   | Native | See **Scale layer** and **ElementWise Layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| And                       | Reconstruction          | Reconstruction | See [op_reconstruction/And.py](op_reconstruction/And.py)
+| Asin                      | None          | Planned in future release  |
+| Asinh                     | None          | Planned in future release  |
+| Atan                      | None          | Planned in future release  |
+| Atanh                     | None          | Planned in future release  |
+| AveragePool               | Native        | Native | See **Pooling layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)                                                                                                           |
+| BatchNormalization        | Native          | Native | See **Scale layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| Celu                      | None          | Planned in future release |
+| Clip                      | Native          | Native |  See **Activation layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/indexhtml#dla-lay-supp-rest)                                                                                      |
+| Concat                    | Native          | Native | See **Concatenation layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| Constant                  | Native          | Native | TensorRT performs constant folding into supported DLA ops.
+| ConstantOfShape           | Can be inferred at build time          | Can be inferred at build time  |
+| Conv                      | Native          | Native | See **Convolution and Fully Connected layers** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| ConvTranspose             | Native          | Native | See **Deconvolution layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| Cos                       | Native          | Planned in future release|
+| Cosh                      | None          | Planned in future release |
+| DepthToSpace              | Reconstruction          | Reconstruction | See [op_reconstruction/DepthToSpace.py](op_reconstruction/DepthToSpace.py)
+| Div                       | None          | Planned in future release |
+| Elu                       | None          | Planned in future release |
+| Equal                     | Native         | Native | See **Equal operation** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| Erf                       | None          | Planned in future release |
+| Exp                       | None          | Planned in future release |
+| Gather                    | Reconstruction          | Reconstruction | See [op_reconstruction/Gather.py](op_reconstruction/Gather.py)
+| Gemm                      | Native          | Native | See **Convolution and Fully Connected layers** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| GlobalAveragePool         | None          | Native |
+| GlobalMaxPool             | None          | Native |
+| Greater                   | None          | Planned in future release |
+| GreaterOrEqual            | None          | Planned in future release |
+| GRU                       | Reconstruction          | Reconstruction | See [op_reconstruction/GRU.py](op_reconstruction/GRU.py)
+| HardSwish                 | None          | Planned in future release |
+| HardSigmoid               | None          | Planned in future release |
+| LeakyRelu                 | Native          | Native | See **Activation layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| Less                      | None          | Planned in future release |
+| LessOrEqual               | None          | Planned in future release |
+| Log                       | None          | Planned in future release |
+| LogSoftmax                | None          | Planned in future release |
+| LRN                       | Native          | Native | See **LRN (Local Response Normalization) layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| MatMul                    | Native          | Native | The second input must be a constant, also see **Convolution and Fully Connected layers** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| Max                       | Native          | Native| See **ElementWise layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| MaxPool                   | Native          | Native| See **Pooling layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| Min                       | None          | Planned in future release |
+| Mod                       | None          | Planned in future release |
+| Mul                       | Native          | Native | See **Scale layer** and **ElementWise layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| Neg                       | Reconstruction          | Reconstruction |  See [op_reconstruction/Neg.py](op_reconstruction/Neg.py)
+| Not                       | Reconstruction          | Reconstruction | See [op_reconstruction/Not.py](op_reconstruction/Not.py)
+| Or                        | Reconstruction          | Reconstruction | See [op_reconstruction/Or.py](op_reconstruction/Or.py)
+| Pow                       | None          | Planned in future release |
+| PRelu                     | Native          | Native | See **Parametric ReLU layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| Reciprocal                | None          | Planned in future release |
+| ReduceMax                 | None          | Native|
+| ReduceMean                | None          | Native|
+| ReduceMin                 | None          | Native|
+| Relu                      | Native          | Native | See **Activation layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| Reshape                   | Native          | Native | See **Shuffle layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| Resize                    | Native         | Native | See **Resize layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)   |
+| ScatterElements           | Reconstruction          | Reconstruction | See [op_reconstruction/ScatterElements.py](op_reconstruction/ScatterElements.py)
+| Shape                     |Can be inferred at build time          | Can be inferred at build time  |
+| Sigmoid                   | Native          | Native | See **Activation layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| Sign                      | None          | Planned in future release |
+| Sin                       | None          | Planned in future release |
+| Sinh                      | None          | Planned in future release |
+| Slice                     | Native         | Native | See **Slice layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)                                                                                                |
+| Softmax                   | Native         | Native | See **SoftMax layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| Softplus                  | None          | Planned in future release |
+| Softsign                  | None          | Planned in future release |
+| SpaceToDepth              | Reconstruction          | Reconstruction | See [op_reconstruction/SpaceToDepth.py](op_reconstruction/SpaceToDepth.py)
+| Sqrt                      | None          | Planned in future release |
+| Sub                       | Native         | Native | See **ElementWise layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| Sum                       | Native         | Native | See **ElementWise layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| Tan                       | None          | Planned in future release |
+| Tanh                      | Native         | Native | See **Activation layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest))
+| ThresholdedRelu           | None          | Planned in future release |
+| Transpose                 | Native         | Native | See **Shuffle layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| Upsample                  | Native         | Native | See **Resize layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| Where                     | Reconstruction          | Reconstruction | See [op_reconstruction/Where.py](op_reconstruction/Where.py)
+| Xor                       | Reconstruction          | Reconstruction | See [op_reconstruction/Xor.py](op_reconstruction/Xor.py)

--- a/operators/README.md
+++ b/operators/README.md
@@ -9,6 +9,8 @@ See [General Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/develop
 
 TensorRT 8.5 supports operators up to Opset 17. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/master/docs/Operators.md).
 
+Note that the scripts in `op_reconstruction/` are intended as a recipe for how ops currently not supported on DLA can be decomposed into supported ops. Depending on your setup, you may choose to perform such op reconstructions in the ONNX domain post-training (as done here) or during the training process (for example in TensorFlow or PyTorch).
+
 ## Operator Support Matrix
 
 | Operator                  | Orin DLA support through TensorRT | Orin DLA support through DLA SW   | Restrictions                                                                                                           |

--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -1,0 +1,20 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2022 - 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#
+"""Common utils for op reconstructions."""
+
+import logging
+import numpy as np
+np.random.seed(0xdeadbeef)
+
+logging.basicConfig(format='%(asctime)s %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s',
+                    datefmt='%m/%d/%Y %I:%M:%S %p',
+                    level=logging.INFO)

--- a/operators/common/BinaryOperator.py
+++ b/operators/common/BinaryOperator.py
@@ -1,0 +1,37 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#
+"""BinaryOperator class for op reconstructions."""
+
+import onnx
+import numpy as np
+import onnx_graphsurgeon as gs
+from common.Operator import Operator
+
+
+class BinaryOperator(Operator):
+    def generate(self, input_shapes, **kwargs):
+        kwargs['dtype'] = np.bool
+        return super().generate(input_shapes, **kwargs)
+
+    def test(self, input_data):
+        if not isinstance(input_data, list):
+            input_data = [input_data]
+        input_shapes = [data.shape for data in input_data]
+        orig_graph = self.generate(input_shapes)
+        orig_path = Operator.save_gs_graph(orig_graph, run_shape_inference=True)
+        reconstructed_graph = gs.import_onnx(onnx.load(orig_path))
+        for node in reconstructed_graph.nodes:
+            self.reconstruct(node, reconstructed_graph)
+        reconstructed_graph.name = orig_graph.name.replace('_orig', '_reconstructed')
+        reconstructed_path = Operator.save_gs_graph(reconstructed_graph)
+        maxabsdiff = self.run_comparison([orig_path, reconstructed_path], input_data=input_data)
+        return maxabsdiff

--- a/operators/common/IndexSelectionOperator.py
+++ b/operators/common/IndexSelectionOperator.py
@@ -1,0 +1,81 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#
+"""IndexSelectionOperator class for reconstructions of Gather/Scatter-style ops."""
+
+import numpy as np
+import onnx_graphsurgeon as gs
+
+from common.Operator import Operator
+
+
+class IndexSelectionOperator(Operator):
+    expected_num_inputs = 1
+
+    @staticmethod
+    def insert_transposes_if_needed(node, graph, axis):
+        transposes_needed = False
+        first_permute = None
+        second_permute = None
+        if axis == 1:
+            transposes_needed = False
+        elif axis == 2:
+            # move axis 2 to 1
+            first_permute = (0, 2, 3, 1)
+            # move axis 1 to 2 again
+            second_permute = (0, 3, 1, 2)
+            transposes_needed = True
+        elif axis == 3:
+            # move axis 3 to 1
+            first_permute = (0, 3, 2, 1)
+            # move axis 1 to 3 again
+            second_permute = (0, 3, 2, 1)
+            transposes_needed = True
+        else:
+            assert False, 'Not implemented'
+        if transposes_needed:
+            nonconst_inputs = [(idx, x) for idx, x in enumerate(node.inputs)
+                               if not isinstance(x, gs.Constant)]
+            new_inputs = list(node.inputs)
+            for orig_idx, inp in nonconst_inputs:
+                orig_input_shape = inp.shape
+                new_input_shape = [orig_input_shape[x] for x in first_permute]
+                first_tmp_tensor = gs.Variable(name=f'{node.name}_transpose0_{orig_idx}',
+                                               dtype=np.float32,
+                                               shape=new_input_shape)
+                first_transpose = gs.Node(op='Transpose',
+                                          inputs=[inp],
+                                          outputs=[first_tmp_tensor],
+                                          attrs=dict(perm=first_permute),
+                                          name=first_tmp_tensor.name)
+                graph.nodes.append(first_transpose)
+                new_inputs[orig_idx] = first_tmp_tensor
+            node.inputs = new_inputs
+            second_tmp_tensor = gs.Variable(name=f'{node.name}_tmp1', dtype=np.float32, shape=None)
+            second_transpose = gs.Node(op='Transpose',
+                                       inputs=[second_tmp_tensor],
+                                       outputs=[node.outputs[0]],
+                                       attrs=dict(perm=second_permute),
+                                       name=second_tmp_tensor.name)
+            graph.nodes.append(second_transpose)
+            node.outputs = [second_tmp_tensor]
+            graph.cleanup().toposort()
+        return transposes_needed
+
+    @classmethod
+    def qualifies_for_reconstruction(cls, node):
+        result = super().qualifies_for_reconstruction(node)
+        if result:
+            axis = node.attrs.get('axis', 0)
+            result = result and len(node.inputs) == cls.expected_num_inputs
+            result &= result and isinstance(node.inputs[1], gs.Constant)
+            result &= result and axis in {1, 2, 3}
+        return result

--- a/operators/common/Operator.py
+++ b/operators/common/Operator.py
@@ -1,0 +1,180 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#
+"""Generic Operator class for op reconstructions."""
+
+from logging import info
+
+from onnx import shape_inference
+import onnx
+import onnx_graphsurgeon as gs
+import os
+import json
+from collections import OrderedDict
+from common.onnxruntime_utils import onnx_inference
+
+import numpy as np
+
+class Operator():
+    def __init__(self):
+        self.node_count = 0
+        self.tensor_count = 0
+        self.op = type(self).__name__
+
+    def generate(self, input_shapes, **kwargs):
+        if not isinstance(input_shapes, list):
+            input_shapes = [input_shapes]
+        dtype = kwargs.get('dtype', np.float32)
+        inputs = [
+            gs.Variable(name=self.new_tensor_name(), dtype=dtype, shape=shape)
+            for shape in input_shapes
+        ]
+        outputs = [gs.Variable(name=self.new_tensor_name(), dtype=dtype)]
+        node = gs.Node(op=self.op, inputs=inputs, outputs=outputs, name=self.new_node_name())
+        if 'attrs' in kwargs:
+            node.attrs = kwargs['attrs']
+        nonconst_inputs = [x for x in node.inputs if not isinstance(x, gs.Constant)]
+        graph = gs.Graph(nodes=[node], inputs=nonconst_inputs, outputs=node.outputs)
+        graph.name = f'{self.op}_orig'
+        return graph
+
+    @classmethod
+    def op_to_reconstruct(cls):
+        return cls.__name__
+
+    @classmethod
+    def qualifies_for_reconstruction(cls, node):
+        return node.op == cls.op_to_reconstruct()
+
+    @classmethod
+    def reconstruct(cls, node, graph, **kwargs):
+        if cls.qualifies_for_reconstruction():
+            # specialize here
+            pass
+
+    def test(self, input_shapes, **kwargs):
+        orig_graph = self.generate(input_shapes, **kwargs)
+        orig_path = Operator.save_gs_graph(orig_graph, run_shape_inference=True)
+        reconstructed_graph = gs.import_onnx(onnx.load(orig_path))
+        for node in reconstructed_graph.nodes:
+            self.reconstruct(node, reconstructed_graph)
+        reconstructed_graph.name = orig_graph.name.replace('_orig', '_reconstructed')
+        reconstructed_graph = Operator.save_gs_graph(reconstructed_graph)
+        maxabsdiff = self.run_comparison([orig_path, reconstructed_graph], input_shapes)
+        return maxabsdiff
+
+    def new_node_name(self):
+        result = f'{self.op}_{self.node_count}'
+        self.node_count += 1
+        return result
+
+    def new_tensor_name(self):
+        result = f'tensor_{self.tensor_count}'
+        self.tensor_count += 1
+        return result
+
+    @staticmethod
+    def save_gs_graph(graph,
+                      top_dir='./models',
+                      run_shape_inference=False,
+                      opset=13,
+                      producer='onnx_graphsurgeon'):
+        graph.opset = opset
+        graph.producer = producer
+        if run_shape_inference:
+            for node in graph.nodes:
+                for out in node.outputs:
+                    out.shape = None
+        model = gs.export_onnx(graph)
+        if run_shape_inference:
+            model = shape_inference.infer_shapes(model)
+        os.makedirs(top_dir, exist_ok=True)
+        nonconst_inputs = [x for x in graph.inputs if not isinstance(x, gs.Constant)]
+        input_shape = 'x'.join([str(x) for x in nonconst_inputs[0].shape])
+        path_name = os.path.join(top_dir, f'{graph.name}_{input_shape}.onnx')
+        info(f'Saving file {path_name}...')
+        onnx.save(model, path_name)
+        return path_name
+
+    def verify_reconstruction(self, onnx_file):
+        graph = gs.import_onnx(onnx.load(onnx_file))
+        for node in graph.nodes:
+            assert node.op != self.op, f'Node "{node.name}" of op type "{node.op}" has not been reconstructed'
+
+    @staticmethod
+    def save_scales(json_path, key_to_range):
+        ranges_dict = OrderedDict()
+        offset = 0
+        for key, (low, high) in key_to_range.items():
+            scale = max(abs(low), abs(high)) / 127.0
+            ranges_dict[key] = dict(scale=scale, min=float(low), max=float(high), offset=offset)
+        with open(json_path, 'w') as outfile:
+            outfile.write(json.dumps(ranges_dict, indent=4))
+
+    def save_inputs_and_ref_outputs(cls, reconstructed_path, inputs, output, dtypes=[np.float16, np.int8]):
+        DTYPE_STRINGS = {np.float16: 'fp16', np.int8: 'int8'}
+        def preprocess(data, dtype):
+            data = data.copy()
+            if dtype == np.int8 and data.dtype != np.bool:
+                dyn_range = max(np.abs(data.max()), np.abs(data.min()))
+                scaling_factor = dyn_range / 127.0
+                data /= scaling_factor
+                data = np.round(data).clip(-127, 127)
+            data = data.astype(dtype)
+            return data
+        results_dir = reconstructed_path.replace('.onnx', '')
+        graph = gs.import_onnx(onnx.load(reconstructed_path))
+        nonconst_inputs = [x for x in graph.inputs if not isinstance(x, gs.Constant)]
+        assert len(nonconst_inputs) == len(inputs)
+        os.makedirs(results_dir, exist_ok=True)
+        key_to_range = dict()
+        for dtype in dtypes:
+            for idx, (inp_data, inp_tensor) in enumerate(zip(inputs, nonconst_inputs)):
+                np.save(os.path.join(results_dir, f'inputs_{idx}_{DTYPE_STRINGS[dtype]}.npy'),
+                        preprocess(inp_data, dtype))
+                if dtype == np.int8:
+                    key_to_range[inp_tensor.name] = (inp_data.min(), inp_data.max())
+            np.save(os.path.join(results_dir, f'outputs_0_{DTYPE_STRINGS[dtype]}.npy'),
+                    preprocess(output, dtype))
+            if dtype == np.int8:
+                key_to_range[graph.outputs[0].inputs[0].name] = (output.min(), output.max())
+        Operator.save_scales(os.path.join(results_dir, 'int8.json'), key_to_range)
+
+    def run_comparison(self,
+                       onnx_paths,
+                       input_shapes=None,
+                       incremental_vals=False,
+                       input_data=None,
+                       index_reconstructed=-1,
+                       session_options=None):
+        assert len(onnx_paths) == 2
+        self.verify_reconstruction(onnx_paths[index_reconstructed])
+        if input_data is None:
+            assert input_shapes is not None
+            if incremental_vals:
+                input_data = [
+                    np.arange(np.product(shape), dtype=np.float32).reshape(shape)
+                    for shape in input_shapes
+                ]
+            else:
+                input_data = [np.random.rand(*shape).astype(np.float32) for shape in input_shapes]
+        else:
+            assert not incremental_vals
+            assert input_shapes is None
+        session_outputs = list()
+        for onnx_file in onnx_paths:
+            output_data = onnx_inference(onnx_file, input_data, session_options)
+            session_outputs.append(output_data[0])
+        maxabsdiff = np.abs(session_outputs[0].flatten().astype(np.float32) -
+                            session_outputs[1].flatten().astype(np.float32)).max()
+        info(f'Max absdiff between {onnx_paths[0]} and {onnx_paths[1]}: {maxabsdiff}')
+        self.save_inputs_and_ref_outputs(onnx_paths[1], input_data, session_outputs[0])
+        return maxabsdiff

--- a/operators/common/__init__.py
+++ b/operators/common/__init__.py
@@ -1,0 +1,21 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2022 - 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#
+"""Common utils for op reconstructions."""
+
+import logging
+import numpy as np
+
+np.random.seed(0xdeadbeef)
+
+logging.basicConfig(format='%(asctime)s %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s',
+                    datefmt='%m/%d/%Y %I:%M:%S %p',
+                    level=logging.INFO)

--- a/operators/common/onnxruntime_utils.py
+++ b/operators/common/onnxruntime_utils.py
@@ -1,0 +1,33 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#
+"""Utils for ONNX Runtime inference."""
+import onnxruntime as ort
+import numpy as np
+
+ONNXRUNTIME_DT_TO_NUMPY_DT = {'tensor(bool)': np.bool, 'tensor(float)': np.float32}
+
+
+
+def onnx_inference(onnx_file, input_data, session_options=None):
+    session = ort.InferenceSession(onnx_file, session_options)
+    if not isinstance(input_data, list):
+        input_data = [input_data]
+    session_inputs = session.get_inputs()
+    assert len(session_inputs) == len(input_data)
+    input_dict = dict()
+    for tensor, data in zip(session_inputs, input_data):
+        assert tensor.type in ONNXRUNTIME_DT_TO_NUMPY_DT, 'No mapping from ONNX RT to NumPy data type detected, you may need to extend it'
+        dtype = ONNXRUNTIME_DT_TO_NUMPY_DT[tensor.type]
+        input_dict[tensor.name] = data.astype(dtype)
+    output_name = session.get_outputs()[0].name
+    output = session.run([output_name], input_dict)
+    return output

--- a/operators/op_reconstruction/And.py
+++ b/operators/op_reconstruction/And.py
@@ -1,0 +1,42 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#
+"""Reconstruction of an And op."""
+
+from logging import info
+from common.BinaryOperator import BinaryOperator
+import numpy as np
+
+
+class And(BinaryOperator):
+    @classmethod
+    def reconstruct(cls, node, graph):
+        if cls.qualifies_for_reconstruction(node):
+            info(f'Reconstructing {node.op} node "{node.name}"...')
+            node.op = 'Mul'
+            for tensor in node.inputs + node.outputs:
+                tensor.dtype = np.float32
+
+    def test(self):
+        input_shapes = [(1, 4, 1, 1)] * 2
+        input_data = list()
+        input_data.append(np.array([True, True, False, False]).reshape(input_shapes[0]))
+        input_data.append(np.array([True, False, True, False]).reshape(input_shapes[1]))
+        return super().test(input_data=input_data)
+
+
+def main():
+    op = And()
+    op.test()
+
+
+if __name__ == '__main__':
+    main()

--- a/operators/op_reconstruction/DepthToSpace.py
+++ b/operators/op_reconstruction/DepthToSpace.py
@@ -1,0 +1,76 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2022 - 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#
+"""Reconstruction of a DepthToSpace op."""
+
+from logging import info
+import numpy as np
+import onnx_graphsurgeon as gs
+
+from common.Operator import Operator
+
+
+class DepthToSpace(Operator):
+    def generate(self, input_shapes, attrs):
+        graph = super().generate(input_shapes, attrs=attrs)
+        mode = attrs.get('mode', 'CRD')
+        graph.name = f'{self.op}_{mode}_orig'
+        return graph
+
+    @classmethod
+    def reconstruct(cls, node, graph):
+        if cls.qualifies_for_reconstruction(node):
+            info(f'Reconstructing {node.op} node "{node.name}"...')
+            mode = node.attrs.get('mode', 'CRD')
+            blocksize = node.attrs.get('blocksize', 1)
+            channels_in = node.inputs[0].shape[1]
+            assert channels_in % (blocksize * blocksize) == 0
+            channels_out = channels_in // (blocksize * blocksize)
+            node.op = 'ConvTranspose'
+            node.attrs = dict(kernel_shape=(blocksize, blocksize), strides=(blocksize, blocksize))
+            weight_shape = (channels_in, channels_out, blocksize, blocksize)
+            weight_vals = np.zeros(weight_shape, dtype=np.float32)
+            if mode == 'CRD':
+                for c in range(channels_in):
+                    filter_slice = weight_vals[c, :].flatten()
+                    filter_slice[c] = 1
+                    weight_vals[c, :] = filter_slice.reshape(channels_out, blocksize, blocksize)
+            elif mode == 'DCR':
+                stacked_kernels = weight_vals.reshape(channels_in,
+                                                      channels_out * blocksize * blocksize)
+                for block_idx in range(channels_in):
+                    kernel_one_idx = block_idx // channels_out + (
+                        block_idx % channels_out) * blocksize * blocksize
+                    stacked_kernels[block_idx][kernel_one_idx] = 1
+                weight_vals = stacked_kernels.reshape(weight_shape)
+            else:
+                assert False, f'Unknown DepthToSpace mode: {mode}'
+            weight_constant = gs.Constant(name=f'{node.name}_tmp0', values=weight_vals)
+            node.inputs.append(weight_constant)
+
+    def test(self, input_shapes=None, blocksize=None, modes=None):
+        input_shapes = input_shapes or [(1, 512, 48, 48)]
+        blocksize = blocksize or 4
+        modes = modes or ['CRD', 'DCR']
+        maxabsdiff = 0.0
+        for mode in modes:
+            attrs = dict(blocksize=blocksize, mode=mode)
+            maxabsdiff = max(super().test(input_shapes, attrs=attrs), maxabsdiff)
+        return maxabsdiff
+
+
+def main():
+    op = DepthToSpace()
+    op.test()
+
+
+if __name__ == '__main__':
+    main()

--- a/operators/op_reconstruction/GRU.py
+++ b/operators/op_reconstruction/GRU.py
@@ -1,0 +1,503 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2022 - 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#
+"""Reconstruction of a GRU op."""
+
+from logging import info
+import onnx_graphsurgeon as gs
+import onnx
+
+from common.Operator import Operator
+from common.onnxruntime_utils import ONNXRUNTIME_DT_TO_NUMPY_DT
+import onnxruntime
+import numpy as np
+
+NUM_DIRECTIONS_DICT = dict(forward=1, reverse=1, bidirectional=2)
+
+
+class GRU(Operator):
+    def generate(self, input_shapes, attrs, use_bias=False, use_initial_h=True):
+        if not isinstance(input_shapes, list):
+            input_shapes = [input_shapes]
+        assert len(input_shapes) in {1, 2}
+        assert len(input_shapes[0]) == 3
+        assert attrs.get('layout', 0) == 1
+        batch_size, seq_length, input_size = input_shapes[0]
+
+        dtype = np.float32
+        inputs = list()
+        hidden_size = attrs.get('hidden_size', 1)
+        direction = attrs.get('direction', 'forward')
+        assert direction in {'forward'}
+
+        num_directions = NUM_DIRECTIONS_DICT[direction]
+        X = gs.Variable(name=self.new_tensor_name(), dtype=dtype, shape=input_shapes[0])
+        W_shape = [num_directions, 3 * hidden_size, input_size]
+        W = gs.Constant(name=self.new_tensor_name(), values=np.random.rand(*W_shape).astype(dtype))
+        R_shape = [num_directions, 3 * hidden_size, hidden_size]
+        R = gs.Constant(name=self.new_tensor_name(), values=np.random.rand(*R_shape).astype(dtype))
+
+        inputs = [X, W, R]
+        if use_bias:
+            B = gs.Constant(name=self.new_tensor_name(),
+                            values=np.random.rand(num_directions, 6 * hidden_size).astype(dtype))
+            inputs += [B]
+        if use_initial_h:
+            if not use_bias:
+                B = gs.Constant(name=self.new_tensor_name(),
+                                values=np.zeros([num_directions, 6 * hidden_size], dtype=dtype))
+                inputs += [B]
+            sequence_lens = gs.Constant(name=self.new_tensor_name(),
+                                        values=np.array([seq_length] * batch_size, dtype=np.int32))
+            initial_h_shape = [batch_size, num_directions, hidden_size]
+            initial_h = gs.Variable(name=self.new_tensor_name(),
+                                    dtype=dtype,
+                                    shape=initial_h_shape)
+            inputs += [sequence_lens, initial_h]
+
+        outputs = [
+            gs.Variable(name='', dtype=dtype),
+            gs.Variable(name=self.new_tensor_name(), dtype=dtype)
+        ]
+        activations = attrs.get('activations', list())
+        if len(activations) > 0:
+            assert len(activations) == 2  # would be 4 for bidirectional
+            attrs['activations'] = activations
+        node = gs.Node(op=self.op,
+                       inputs=inputs,
+                       outputs=outputs,
+                       attrs=attrs,
+                       name=self.new_node_name())
+        graph_inputs = [inp for inp in node.inputs if not isinstance(inp, gs.Constant)]
+        graph = gs.Graph(nodes=[node],
+                         inputs=graph_inputs,
+                         outputs=[node.outputs[-1]],
+                         name=node.name)
+        graph.name = f'{self.op}_bias{int(use_bias)}_initialh{int(use_initial_h)}_orig'
+        return graph
+
+    @staticmethod
+    def from2dto4d(data):
+        return np.expand_dims(data, [-2, -1])
+
+    @staticmethod
+    def add_gru_conv(graph, var_input, prefix, conv_wt_vals, conv_bias_vals, index, dtype):
+        assert isinstance(var_input, gs.Variable)
+        conv_out = gs.Variable(name=prefix, dtype=dtype)
+        conv_Wt = gs.Constant(name=f'{prefix}_wt', values=np.copy(conv_wt_vals[index]))
+        inputs = [var_input, conv_Wt]
+        if conv_bias_vals[index] is not None:
+            inputs.append(gs.Constant(name=f'{prefix}_bias',
+                                      values=np.copy(conv_bias_vals[index])))
+        conv = gs.Node(op='Conv', inputs=inputs, outputs=[conv_out], name=conv_out.name)
+        graph.nodes.append(conv)
+        return conv_out
+
+    @staticmethod
+    def add_gru_bias(conv_node, conv_bias_vals, index):
+        if len(conv_node.inputs) < 3:
+            return
+        bias = conv_node.inputs[2]
+        if conv_bias_vals[index] is not None:
+            bias.values += conv_bias_vals[index]
+
+    @staticmethod
+    def add_gru_elementwise(graph, ew_op, var_inputs, prefix, dtype, ew_out=None):
+        assert isinstance(var_inputs, list)
+        ew_out = ew_out or gs.Variable(name=prefix, dtype=dtype)
+        ew = gs.Node(op=ew_op, inputs=var_inputs, outputs=[ew_out], name=ew_out.name)
+        graph.nodes.append(ew)
+        return ew_out
+
+    @staticmethod
+    def add_gru_act(graph, act_op, var_input, prefix, dtype):
+        assert isinstance(var_input, gs.Variable)
+        act_out = gs.Variable(name=prefix, dtype=dtype)
+        act = gs.Node(op=act_op, inputs=[var_input], outputs=[act_out], name=act_out.name)
+        graph.nodes.append(act)
+        return act_out
+
+    @staticmethod
+    def add_gru_transpose(graph, var_input, perm, prefix, dtype):
+        transpose_out = gs.Variable(name=prefix, dtype=dtype)
+        transpose = gs.Node(op='Transpose',
+                            inputs=[var_input],
+                            outputs=[transpose_out],
+                            attrs=dict(perm=perm),
+                            name=transpose_out.name)
+        graph.nodes.append(transpose)
+        return transpose_out
+
+    @staticmethod
+    def add_gru_slice(graph, slice_channel_idx, slice_axis, var_input, prefix, dtype):
+        assert isinstance(var_input, gs.Variable)
+        slice_out = gs.Variable(name=prefix, dtype=dtype)
+        starts = gs.Constant(name=f'{prefix}_starts',
+                             values=np.array([slice_channel_idx], dtype=np.int64))
+        ends = gs.Constant(name=f'{prefix}_ends',
+                           values=np.array([slice_channel_idx + 1], dtype=np.int64))
+        axes = gs.Constant(name=f'{prefix}_axes', values=np.array([slice_axis], dtype=np.int64))
+        steps = gs.Constant(name=f'{prefix}_steps', values=np.array([1], dtype=np.int64))
+        slice = gs.Node(op='Slice',
+                        inputs=[var_input, starts, ends, axes, steps],
+                        outputs=[slice_out],
+                        name=slice_out.name)
+        graph.nodes.append(slice)
+        return slice_out
+
+    @staticmethod
+    def add_gru_const_op(graph, const_op, var_input, const_vals, prefix, dtype):
+        assert isinstance(var_input, gs.Variable)
+        assert isinstance(const_vals, np.ndarray)
+        op_out = gs.Variable(name=prefix, dtype=dtype)
+        const_vals = const_vals.reshape(1, -1, 1, 1)
+        const_input = gs.Constant(name=f'{prefix}_const', values=const_vals.astype(dtype))
+        op = gs.Node(op=const_op,
+                     inputs=[var_input, const_input],
+                     outputs=[op_out],
+                     name=op_out.name)
+        graph.nodes.append(op)
+        return op_out
+
+    @staticmethod
+    def reconstruct_step(graph, node, step_idx, total_steps, X_slice, Ht_prev, W_vals, Wb_vals,
+                         R_vals, Rb_vals, f, g, dtype, linear_before_reset):
+        zt_index_W = 0
+        zt_index_R = 0
+        rt_index_W = 1
+        rt_index_R = 1
+        ht_index_W = 2
+        ht_index_R = 2
+        base_prefix = f'{node.name}_step{step_idx}'
+        last_out = node.outputs[-1] if step_idx == total_steps - 1 else None
+        if Ht_prev is not None:
+            # zt = f(Xt*(Wz^T) + Ht-1*(Rz^T) + Wbz + Rbz)
+            zt_X_out = GRU.add_gru_conv(graph, X_slice, f'{base_prefix}_zt_X', W_vals, Wb_vals,
+                                        zt_index_W, dtype)
+            zt_Ht_out = GRU.add_gru_conv(graph, Ht_prev, f'{base_prefix}_zt_Ht-1', R_vals, Rb_vals,
+                                         zt_index_R, dtype)
+            zt_add_out = GRU.add_gru_elementwise(graph, 'Add', [zt_X_out, zt_Ht_out],
+                                                 f'{base_prefix}_zt_add', dtype)
+            zt_act_out = GRU.add_gru_act(graph, f, zt_add_out, f'{base_prefix}_zt_act_f', dtype)
+            # rt = f(Xt*(Wr^T) + Ht-1*(Rr^T) + Wbr + Rbr)
+            rt_X_out = GRU.add_gru_conv(graph, X_slice, f'{base_prefix}_rt_X', W_vals, Wb_vals,
+                                        rt_index_W, dtype)
+            rt_Ht_out = GRU.add_gru_conv(graph, Ht_prev, f'{base_prefix}_rt_Ht-1', R_vals, Rb_vals,
+                                         rt_index_R, dtype)
+            rt_add_out = GRU.add_gru_elementwise(graph, 'Add', [rt_X_out, rt_Ht_out],
+                                                 f'{base_prefix}_rt_add', dtype)
+            rt_act_out = GRU.add_gru_act(graph, f, rt_add_out, f'{base_prefix}_rt_act_f', dtype)
+
+            # Xt*(Wh^T)
+            ht_X_out = GRU.add_gru_conv(graph, X_slice, f'{base_prefix}_X_ht', W_vals, Wb_vals,
+                                        ht_index_W, dtype)
+            # (rt (.) Ht-1)
+            ht_mul_out = GRU.add_gru_elementwise(graph, 'Mul', [rt_act_out, Ht_prev],
+                                                 f'{base_prefix}_Ht_mul', dtype)
+            # (rt (.) Ht-1)*(Rh^T)
+            ht_Ht_out = GRU.add_gru_conv(graph, ht_mul_out, f'{base_prefix}_Ht', R_vals, Rb_vals,
+                                         ht_index_R, dtype)
+            # Xt*(Wh^T) + (rt (.) Ht-1)*(Rh^T) + Rbh + Wbh
+            X_Ht_add_out = GRU.add_gru_elementwise(graph, 'Add', [ht_Ht_out, ht_X_out],
+                                                   f'{base_prefix}_X_Ht_add', dtype)
+            # linear_before_reset = 0: ht = g(Xt*(Wh^T) + (rt (.) Ht-1)*(Rh^T) + Rbh + Wbh)
+            X_Ht_act_out = GRU.add_gru_act(graph, g, X_Ht_add_out, f'{base_prefix}_X_Ht_g', dtype)
+            # linear_before_reset != 0: ht = g(Xt*(Wh^T) + (rt (.) (Ht-1*(Rh^T) + Rbh)) + Wbh)
+            # h_default = self.g(np.dot(x, np.transpose(w_h)) + np.dot(r * H_t, np.transpose(r_h)) + w_bh + r_bh)
+            # h_linear = self.g(np.dot(x, np.transpose(w_h)) + r * (np.dot(H_t, np.transpose(r_h)) + r_bh) + w_bh)
+            # h = h_linear if self.LBR else h_default
+            # (1 - zt)
+            zt_sub_out = GRU.add_gru_const_op(graph, 'Add', zt_act_out, np.array([-1]),
+                                              f'{base_prefix}_zt_const_add', dtype)
+            zt_mul_out = GRU.add_gru_const_op(graph, 'Mul', zt_sub_out, np.array([-1]),
+                                              f'{base_prefix}_zt_const_mul', dtype)
+            # (1 - zt) (.) ht
+            zt_mul0_out = GRU.add_gru_elementwise(graph, 'Mul', [zt_mul_out, X_Ht_act_out],
+                                                  f'{base_prefix}_zt_mul0', dtype)
+            # zt (.) Ht-1
+            zt_mul1_out = GRU.add_gru_elementwise(graph, 'Mul', [zt_act_out, Ht_prev],
+                                                  f'{base_prefix}_zt_mul1', dtype)
+            # Ht = (1 - zt) (.) ht + zt (.) Ht-1
+            out = GRU.add_gru_elementwise(graph,
+                                          'Add', [zt_mul0_out, zt_mul1_out],
+                                          f'{base_prefix}_out',
+                                          dtype,
+                                          ew_out=last_out)
+        else:
+            # zt = f(Xt*(Wz^T) + Wbz + Rbz)
+            zt_X_out = GRU.add_gru_conv(graph, X_slice, f'{base_prefix}_zt_X', W_vals, Wb_vals,
+                                        zt_index_W, dtype)
+            GRU.add_gru_bias(graph.nodes[-1], Rb_vals, zt_index_R)
+
+            zt_act_out = GRU.add_gru_act(graph, f, zt_X_out, f'{base_prefix}_zt_act_f', dtype)
+
+            # Xt*(Wh^T)
+            ht_X_out = GRU.add_gru_conv(graph, X_slice, f'{base_prefix}_X_ht', W_vals, Wb_vals,
+                                        ht_index_W, dtype)
+            GRU.add_gru_bias(graph.nodes[-1], Rb_vals, ht_index_R)
+
+            # ht = g(Xt*(Wh^T) + (rt (.) Ht-1)*(Rh^T) + Rbh + Wbh)
+            Ht_act_out = GRU.add_gru_act(graph, g, ht_X_out, f'{base_prefix}_X_Ht_g', dtype)
+            # (1 - zt)
+            zt_sub_out = GRU.add_gru_const_op(graph, 'Add', zt_act_out, np.array([-1]),
+                                              f'{base_prefix}_zt_const_add', dtype)
+            zt_mul_out = GRU.add_gru_const_op(graph, 'Mul', zt_sub_out, np.array([-1]),
+                                              f'{base_prefix}_zt_const_mul', dtype)
+            # (1 - zt) (.) ht
+            out = GRU.add_gru_elementwise(graph,
+                                          'Mul', [zt_mul_out, Ht_act_out],
+                                          f'{base_prefix}_zt_mul0',
+                                          dtype,
+                                          ew_out=last_out)
+        return out
+
+    @staticmethod
+    def qualifies_for_reconstruction(node):
+        result = node.op == 'GRU'
+        SUPPORTED_GRU_ACTIVATIONS = {'Sigmoid', 'Tanh', 'Relu'}
+        SUPPORTED_GRU_DIRECTIONS = {'forward'}
+        if result:
+            attrs = node.attrs
+            result &= attrs.get('layout', 0) == 1
+            result &= attrs.get('linear_before_reset', 0) == 0
+            result &= attrs.get('direction', 'forward') in SUPPORTED_GRU_DIRECTIONS
+            result &= attrs.get('activation_alpha', None) is None
+            result &= attrs.get('activation_beta', None) is None
+            result &= attrs.get('clip', None) is None
+            activations = attrs.get('activations', ['Sigmoid', 'Tanh'])
+            result &= len(activations) == 2
+            if result:
+                f, g = activations
+                result &= f in SUPPORTED_GRU_ACTIVATIONS
+                result &= g in SUPPORTED_GRU_ACTIVATIONS
+        return result
+
+    @staticmethod
+    def reconstruct(node, graph):
+        if GRU.qualifies_for_reconstruction(node):
+            info(f'Reconstructing {node.op} node "{node.name}"...')
+            X, W, R = node.inputs[:3]
+
+            batch_size, seq_length, input_size = X.shape
+            dtype = X.dtype
+            attrs = node.attrs
+            hidden_size = attrs['hidden_size']
+            direction = attrs.get('direction', 'forward')
+            activations = attrs.get('activations', ['Sigmoid', 'Tanh'])
+            linear_before_reset = attrs.get('linear_before_reset', 0) == 1
+            f, g = activations
+            num_directions = NUM_DIRECTIONS_DICT[direction]
+            Ht_prev_shape = [batch_size, hidden_size, num_directions, 1]
+            Ht_prev = None
+            if len(node.inputs) > 5:
+                Ht_prev = node.inputs[5]
+                Ht_prev.shape = Ht_prev_shape
+            assert isinstance(W, gs.Constant)
+            W_vals = [
+                GRU.from2dto4d(W.values[0, x * hidden_size:(x + 1) * hidden_size])
+                for x in range(3)
+            ]
+            assert isinstance(R, gs.Constant)
+            R_vals = [
+                GRU.from2dto4d(R.values[0, x * hidden_size:(x + 1) * hidden_size])
+                for x in range(3)
+            ]
+            Wb_vals = [None, None, None]
+            Rb_vals = [None, None, None]
+            if len(node.inputs) > 3:
+                assert isinstance(node.inputs[3], gs.Constant)
+                B_vals = node.inputs[3].values
+                B_dims = B_vals.shape
+                assert B_dims[0] == 1
+                cutoff = B_dims[1] // 6
+                vals = [B_vals[0, x * cutoff:(x + 1) * cutoff] for x in range(6)]
+                Wb_vals = vals[:3]
+                Rb_vals = vals[3:]
+
+            if seq_length == 1:
+                X.shape = [batch_size, input_size, 1, 1]
+                out = GRU.reconstruct_step(graph, node, 0, seq_length, X, Ht_prev, W_vals, Wb_vals,
+                                           R_vals, Rb_vals, f, g, dtype, linear_before_reset)
+            else:
+                X.shape = [batch_size, seq_length, input_size, 1]
+                X_transposed = GRU.add_gru_transpose(graph, X, (0, 2, 1, 3),
+                                                     f'{node.name}_transpose_in', dtype)
+                for step_idx in range(seq_length):
+                    X_slice = GRU.add_gru_slice(graph, step_idx, 2, X_transposed,
+                                                f'{node.name}_slice{step_idx}', dtype)
+                    Ht_prev = GRU.reconstruct_step(graph, node, step_idx, seq_length, X_slice,
+                                                   Ht_prev, W_vals, Wb_vals, R_vals, Rb_vals, f, g,
+                                                   dtype, linear_before_reset)
+                out = Ht_prev
+            node.inputs.clear()
+            node.outputs.clear()
+            graph.cleanup().toposort()
+
+    @staticmethod
+    def onnx_inference(session, input_data, prev_output, reshape_input_dims=None):
+        if not isinstance(input_data, list):
+            input_data = [input_data]
+        session_inputs = session.get_inputs()
+        if reshape_input_dims is not None:
+            input_data[0] = np.reshape(input_data, reshape_input_dims)
+        if len(session_inputs) == 2:
+            input_data = [input_data[0], prev_output]
+        assert len(session_inputs) == len(
+            input_data), f'{len(session_inputs)} != {len(input_data)}'
+        input_dict = dict()
+        for tensor, data in zip(session_inputs, input_data):
+            assert tensor.type in ONNXRUNTIME_DT_TO_NUMPY_DT, 'No mapping from ONNX RT to NumPy data type detected, you may need to extend it'
+            dtype = ONNXRUNTIME_DT_TO_NUMPY_DT[tensor.type]
+            if data is None:
+                data = np.zeros(tensor.shape)
+            input_dict[tensor.name] = data.astype(dtype)
+        output_names = [out.name for out in session.get_outputs()]
+        outputs = session.run(output_names, input_dict)
+        return outputs
+
+    @staticmethod
+    def insert_transpose(graph, node, input_direction=True):
+        perm = (1, 0, 2)
+        tensors = node.inputs if input_direction else node.outputs
+        for idx, tensor in enumerate(tensors):
+            if not isinstance(tensor, gs.Constant):
+                transpose_name = f'{tensor.name}_transpose'
+                transpose_tmp = gs.Variable(name=transpose_name, dtype=tensor.dtype)
+                if input_direction:
+                    node_inputs = [tensor]
+                    node_outputs = [transpose_tmp]
+                    node.inputs[idx] = transpose_tmp
+                else:
+                    node_inputs = [transpose_tmp]
+                    node_outputs = [tensor]
+                    node.outputs[idx] = transpose_tmp
+                transpose_node = gs.Node(op='Transpose',
+                                         attrs=dict(perm=perm),
+                                         name=transpose_name,
+                                         inputs=node_inputs,
+                                         outputs=node_outputs)
+                graph.nodes.append(transpose_node)
+
+    @staticmethod
+    def patch_gru_layout(onnx_path_orig):
+        # layout 1 is not supported in ONNX Runtime on CPU yet:
+        # initialization: /Users/runner/work/1/s/onnxruntime/core/providers/cpu/rnn/deep_cpu_gru.h:55 onnxruntime::DeepCpuGruOp::DeepCpuGruOp(const onnxruntime::OpKernelInfo &) layout_ == 0 was false. Batchwise recurrent operations (layout == 1) are not supported. If you need support create a github issue with justification
+        graph = gs.import_onnx(onnx.load(onnx_path_orig))
+        patched = False
+        patched_path = onnx_path_orig
+        for node in graph.nodes:
+            if node.op == 'GRU' and node.attrs.get('layout', 0) == 1:
+                node.attrs['layout'] = 0
+                GRU.insert_transpose(graph, node, input_direction=True)
+                GRU.insert_transpose(graph, node, input_direction=False)
+                patched = True
+        if patched:
+            graph.cleanup().toposort()
+            patched_path = 'tmp.onnx'
+            onnx.save(gs.export_onnx(graph), patched_path)
+        return patched_path
+
+    def run_comparison(self,
+                       onnx_paths,
+                       input_shapes=None,
+                       incremental_vals=False,
+                       input_data=None,
+                       num_iterations=3,
+                       index_reconstructed=-1):
+        assert len(onnx_paths) == 2
+        self.verify_reconstruction(onnx_paths[index_reconstructed][0])
+        if input_data is None:
+            assert input_shapes is not None
+            if incremental_vals:
+                input_data = [
+                    np.arange(np.product(shape), dtype=np.float32).reshape(shape)
+                    for shape in input_shapes
+                ]
+            else:
+                input_data = [np.random.rand(*shape).astype(np.float32) for shape in input_shapes]
+        else:
+            assert not incremental_vals
+            assert input_shapes is None
+        index_orig = index_reconstructed - 1
+        onnx_paths[index_orig] = list(onnx_paths[index_orig])
+        onnx_paths[index_orig][0] = GRU.patch_gru_layout(onnx_paths[index_orig][0])
+        session_outputs = list()
+        for onnx_file, reshape_input_dims in onnx_paths:
+            session = onnxruntime.InferenceSession(onnx_file)
+            prev_output = None
+            iteration_outputs = list()
+            for _ in range(num_iterations):
+                session_output = GRU.onnx_inference(session, input_data, prev_output,
+                                                    reshape_input_dims)
+                prev_output = session_output[0]
+                iteration_outputs.append(prev_output)
+            session_outputs.append(iteration_outputs)
+        for iteration in range(num_iterations):
+            maxabsdiff = np.abs(session_outputs[0][iteration].flatten().astype(np.float32) -
+                                session_outputs[1][iteration].flatten().astype(np.float32)).max()
+        info(
+            f'Max absdiff between {onnx_paths[0]} and {onnx_paths[1]} after {num_iterations} iterations: {maxabsdiff}'
+        )
+        return maxabsdiff
+
+    def test_config(self,
+                    input_shapes=None,
+                    hidden_size=None,
+                    num_iterations=None,
+                    use_bias=False,
+                    use_initial_h=True,
+                    linear_before_reset=0,
+                    layout=1):
+        attrs = dict(hidden_size=hidden_size,
+                     linear_before_reset=linear_before_reset,
+                     layout=layout)
+        orig_graph = self.generate(input_shapes,
+                                   attrs,
+                                   use_bias=use_bias,
+                                   use_initial_h=use_initial_h)
+        orig_path = Operator.save_gs_graph(orig_graph, run_shape_inference=True, opset=14)
+        reconstructed_graph = gs.import_onnx(onnx.load(orig_path))
+        for node in reconstructed_graph.nodes:
+            self.reconstruct(node, reconstructed_graph)
+        reconstructed_graph.name = orig_graph.name.replace('_orig', '_reconstructed')
+        reconstructed_path = GRU.save_gs_graph(reconstructed_graph, run_shape_inference=True)
+        reconstructed_input_shape = reconstructed_graph.inputs[0].shape
+        maxabsdiff = self.run_comparison([(orig_path, None),
+                                          (reconstructed_path, reconstructed_input_shape)],
+                                         input_shapes=input_shapes,
+                                         num_iterations=num_iterations)
+        return maxabsdiff
+
+    def test(self, input_shapes=None, hidden_size=None, num_iterations=None):
+        input_shapes = input_shapes or [(2, 4, 3)]
+        hidden_size = hidden_size or 5
+        num_iterations = num_iterations or 2
+        maxabsdiff = 0.0
+        for use_bias in [False, True]:
+            for use_initial_h in [False, True]:
+                maxabsdiff = max(
+                    maxabsdiff,
+                    self.test_config(input_shapes=input_shapes,
+                                     hidden_size=hidden_size,
+                                     num_iterations=num_iterations,
+                                     use_bias=use_bias,
+                                     use_initial_h=use_initial_h))
+        return maxabsdiff
+
+
+def main():
+    op = GRU()
+    num_iterations = 3
+    op.test(num_iterations=num_iterations)
+
+
+if __name__ == '__main__':
+    main()

--- a/operators/op_reconstruction/Gather.py
+++ b/operators/op_reconstruction/Gather.py
@@ -1,0 +1,97 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2022 - 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#
+"""Reconstruction of a Gather op."""
+
+from logging import info
+import onnx
+import numpy as np
+import onnx_graphsurgeon as gs
+
+from common.IndexSelectionOperator import IndexSelectionOperator
+
+
+class Gather(IndexSelectionOperator):
+    expected_num_inputs = 2
+
+    def generate(self, input_shapes, attrs, num_indices):
+        assert len(input_shapes) == 1
+        input_shape = input_shapes[0]
+        dtype = np.float32
+        var_input = gs.Variable(name=self.new_tensor_name(), dtype=dtype, shape=input_shape)
+        outputs = [gs.Variable(name=self.new_tensor_name(), dtype=dtype)]
+        axis = attrs.get('axis', 0)
+        index_vals = np.arange(input_shape[axis], dtype=np.int64)
+        np.random.shuffle(index_vals)
+        index_vals = index_vals[:num_indices]
+        index_constant = gs.Constant(name=self.new_tensor_name(), values=index_vals)
+        node = gs.Node(op=self.op,
+                       inputs=[var_input, index_constant],
+                       outputs=outputs,
+                       name=self.new_node_name())
+        node.attrs = attrs
+        graph = gs.Graph(nodes=[node], inputs=[var_input], outputs=node.outputs, name=node.name)
+        graph.name = f'{self.op}_axis{axis}_orig'
+        return graph
+
+    @classmethod
+    def reconstruct(cls, node, graph):
+        if cls.qualifies_for_reconstruction(node):
+            info(f'Reconstructing {node.op} node "{node.name}"...')
+            orig_axis = node.attrs.get('axis', 0)
+            transposes_needed = IndexSelectionOperator.insert_transposes_if_needed(
+                node, graph, orig_axis)
+            if transposes_needed:
+                node.attrs['axis'] = 1
+            axis = node.attrs.get('axis', 0)
+            assert axis == 1
+            channels_in = node.inputs[0].shape[1]
+            indices = node.inputs[1]
+            assert len(indices.shape) == 1
+            channels_out = indices.shape[0]
+            node.op = 'Conv'
+            node.attrs.clear()
+            weight_shape = (channels_out, channels_in, 1, 1)
+            weight_vals = np.zeros(weight_shape, dtype=np.float32)
+            for c_out, c_in in enumerate(indices.values.flatten()):
+                weight_vals[c_out, c_in, :, :] = 1
+            weight_constant = gs.Constant(name=f'{node.name}_tmp0', values=weight_vals)
+            node.inputs = [node.inputs[0], weight_constant]
+            graph.cleanup()
+
+    def test(self, input_shapes=None, num_indices=None, axes=None):
+        input_shapes = input_shapes or [(1, 5, 6, 7)]
+        num_indices = num_indices or 3
+        axes = axes or [1, 2, 3]
+        maxabsdiff = 0.0
+        for axis in axes:
+            attrs = dict(axis=axis)
+            orig_graph = self.generate(input_shapes, attrs, num_indices)
+            orig_path = IndexSelectionOperator.save_gs_graph(orig_graph, run_shape_inference=True)
+            reconstructed_graph = gs.import_onnx(onnx.load(orig_path))
+            for node in reconstructed_graph.nodes:
+                self.reconstruct(node, reconstructed_graph)
+            reconstructed_graph.name = orig_graph.name.replace('_orig', '_reconstructed')
+            reconstructed_path = IndexSelectionOperator.save_gs_graph(reconstructed_graph)
+            maxabsdiff_axis = self.run_comparison([orig_path, reconstructed_path],
+                                                  input_shapes=input_shapes,
+                                                  incremental_vals=True)
+            maxabsdiff = max(maxabsdiff_axis, maxabsdiff)
+        return maxabsdiff
+
+
+def main():
+    op = Gather()
+    op.test()
+
+
+if __name__ == '__main__':
+    main()

--- a/operators/op_reconstruction/Neg.py
+++ b/operators/op_reconstruction/Neg.py
@@ -1,0 +1,49 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#
+"""Reconstruction of a Neg op."""
+
+from logging import info
+import numpy as np
+import onnx_graphsurgeon as gs
+
+from common.Operator import Operator
+
+
+class Neg(Operator):
+    def generate(self, input_shapes, **kwargs):
+        # modify here
+        graph = super().generate(input_shapes, **kwargs)
+        return graph
+
+    @classmethod
+    def reconstruct(cls, node, graph):
+        if cls.qualifies_for_reconstruction(node):
+            info(f'Reconstructing {node.op} node "{node.name}"...')
+            node.op = 'Mul'
+            node.attrs.clear()
+            mul_shape = (1, )
+            mul_vals = np.zeros(mul_shape, dtype=np.float32)
+            mul_vals.fill(-1.0)
+            mul_constant = gs.Constant(name=f'{node.name}_tmp0', values=mul_vals)
+            node.inputs.append(mul_constant)
+
+    def test(self, input_shapes=[(1, 2, 3, 4)], **kwargs):
+        return super().test(input_shapes, **kwargs)
+
+
+def main():
+    op = Neg()
+    op.test()
+
+
+if __name__ == '__main__':
+    main()

--- a/operators/op_reconstruction/Not.py
+++ b/operators/op_reconstruction/Not.py
@@ -1,0 +1,46 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#
+"""Reconstruction of a Not op."""
+
+from logging import info
+import numpy as np
+import onnx_graphsurgeon as gs
+
+from common.BinaryOperator import BinaryOperator
+
+
+class Not(BinaryOperator):
+    @classmethod
+    def reconstruct(cls, node, graph):
+        if cls.qualifies_for_reconstruction(node):
+            info(f'Reconstructing {node.op} node "{node.name}"...')
+            node.op = 'Sub'
+            for tensor in node.inputs + node.outputs:
+                tensor.dtype = np.float32
+            not_var = node.inputs[0]
+            not_constant = gs.Constant(name=f'{node.name}_tmp0',
+                                       values=np.ones(not_var.shape, dtype=not_var.dtype))
+            node.inputs = [not_constant, not_var]
+
+    def test(self):
+        input_shape = (1, 2, 1, 1)
+        input_data = np.array([True, False]).reshape(input_shape)
+        return super().test(input_data=input_data)
+
+
+def main():
+    op = Not()
+    op.test()
+
+
+if __name__ == '__main__':
+    main()

--- a/operators/op_reconstruction/Or.py
+++ b/operators/op_reconstruction/Or.py
@@ -1,0 +1,55 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2022 - 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#
+"""Reconstruction of an Or op."""
+
+from logging import info
+import numpy as np
+import onnx_graphsurgeon as gs
+
+from common.BinaryOperator import BinaryOperator
+
+
+class Or(BinaryOperator):
+    @classmethod
+    def reconstruct(cls, node, graph):
+        if cls.qualifies_for_reconstruction(node):
+            info(f'Reconstructing {node.op} node "{node.name}"...')
+            node.op = 'Add'
+            for tensor in node.inputs + node.outputs:
+                tensor.dtype = np.float32
+            tmp_tensor = gs.Variable(name=f'{node.name}_tmp0', dtype=np.float32)
+            clip_min = gs.Constant(name=f'{node.name}_tmp1',
+                                   values=np.zeros((1, ), dtype=np.float32))
+            clip_max = gs.Constant(name=f'{node.name}_tmp2',
+                                   values=np.ones((1, ), dtype=np.float32))
+            clip_node = gs.Node(op='Clip',
+                                inputs=[tmp_tensor, clip_min, clip_max],
+                                outputs=[node.outputs[0]],
+                                name=f'{node.name}_clip')
+            node.outputs = [tmp_tensor]
+            graph.nodes.append(clip_node)
+
+    def test(self):
+        input_shapes = [(1, 4, 1, 1)] * 2
+        input_data = list()
+        input_data.append(np.array([True, True, False, False]).reshape(input_shapes[0]))
+        input_data.append(np.array([True, False, True, False]).reshape(input_shapes[1]))
+        return super().test(input_data=input_data)
+
+
+def main():
+    op = Or()
+    op.test()
+
+
+if __name__ == '__main__':
+    main()

--- a/operators/op_reconstruction/ScatterElements.py
+++ b/operators/op_reconstruction/ScatterElements.py
@@ -1,0 +1,173 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#
+"""Reconstruction of a ScatterElements op."""
+
+from logging import info
+import onnx
+import numpy as np
+import onnx_graphsurgeon as gs
+
+from common.IndexSelectionOperator import IndexSelectionOperator
+from pdb import set_trace
+
+SCATTER_ELEMENTS_SUPPORTED_REDUCTIONS = {'none'}
+
+
+class ScatterElements(IndexSelectionOperator):
+    expected_num_inputs = 3
+
+    def generate(self, input_shapes, attrs, num_indices):
+        assert len(input_shapes) == 2
+        data_shape, updates_shape = input_shapes
+        dtype = np.float32
+        var_input_data = gs.Variable(name=self.new_tensor_name(), dtype=dtype, shape=data_shape)
+        var_input_updates = gs.Variable(name=self.new_tensor_name(),
+                                        dtype=dtype,
+                                        shape=updates_shape)
+        outputs = [gs.Variable(name=self.new_tensor_name(), dtype=dtype)]
+        axis = attrs.get('axis', 0)
+        index_vals = np.arange(data_shape[axis], dtype=np.int64)
+        np.random.shuffle(index_vals)
+        index_shape = [1] * 4
+        index_shape[axis] = num_indices
+        index_vals = index_vals[:num_indices].reshape(index_shape)
+        index_tile_dims = list(updates_shape)
+        index_tile_dims[0] = 1
+        index_tile_dims[axis] = 1
+        index_vals = np.tile(index_vals, index_tile_dims)
+
+        index_constant = gs.Constant(name=self.new_tensor_name(), values=index_vals)
+        node = gs.Node(op=self.op,
+                       inputs=[var_input_data, index_constant, var_input_updates],
+                       outputs=outputs,
+                       name=self.new_node_name())
+        node.attrs = attrs
+        graph = gs.Graph(nodes=[node],
+                         inputs=[var_input_data, var_input_updates],
+                         outputs=node.outputs,
+                         name=node.name)
+        graph.name = f'{self.op}_axis{axis}_orig'
+        return graph
+
+    @classmethod
+    def qualifies_for_reconstruction(cls, node):
+        result = super().qualifies_for_reconstruction(node)
+        nonconst_inputs = [x for x in node.inputs if not isinstance(x, gs.Constant)]
+        axis = node.attrs.get('axis', 0)
+        if result:
+            reduction = node.attrs.get('reduction', 'none')
+            result = reduction in SCATTER_ELEMENTS_SUPPORTED_REDUCTIONS
+            result &= len(nonconst_inputs) == 2
+        if result:
+            indices = node.inputs[1].values
+            for slice_idx in range(indices.shape[axis]):
+                slice_data = np.take(indices, slice_idx, axis).flatten()
+                if not (slice_data[0] == slice_data).all():
+                    result = False
+                    break
+        return result
+
+    @staticmethod
+    def insert_transposes_if_needed(node, graph):
+        orig_axis = node.attrs.get('axis', 0)
+        transposes_needed = IndexSelectionOperator.insert_transposes_if_needed(
+            node, graph, orig_axis)
+        if transposes_needed:
+            if orig_axis == 2:
+                first_permute = (0, 2, 3, 1)
+            elif orig_axis == 3:
+                first_permute = (0, 3, 2, 1)
+            elif orig_axis == 1:
+                assert False, 'Should not have required to transpose'
+            else:
+                assert False, 'Not implemented'
+            node.attrs['axis'] = 1
+            indices = node.inputs[1]
+            indices.values = np.transpose(indices.values, first_permute)
+
+    @classmethod
+    def reconstruct(cls, node, graph):
+        if cls.qualifies_for_reconstruction(node):
+            info(f'Reconstructing {node.op} node "{node.name}"...')
+            cls.insert_transposes_if_needed(node, graph)
+            axis = node.attrs.get('axis', 0)
+            assert axis == 1
+            data, indices, updates = node.inputs
+            index_vals = indices.values[0, :, 0, 0]
+            indices_set = set(index_vals)
+            channels_in_conv = updates.shape[1]
+            channels_out_conv = data.shape[1]
+            conv_weight_shape = (channels_out_conv, channels_in_conv, 1, 1)
+            conv_weight_vals = np.zeros(conv_weight_shape, dtype=np.float32)
+            for c_in, c_out in enumerate(index_vals):
+                conv_weight_vals[c_out, c_in, :, :] = 1
+            conv_output = gs.Variable(name=f'{node.name}_conv_tmp0', dtype=updates.dtype)
+            conv_weight_constant = gs.Constant(name=f'{node.name}_conv_tmp1',
+                                               values=conv_weight_vals)
+            conv_node = gs.Node(op='Conv',
+                                inputs=[updates, conv_weight_constant],
+                                outputs=[conv_output],
+                                name=f'{node.name}_conv')
+            graph.nodes.append(conv_node)
+            scale_weight_shape = (1, channels_out_conv, 1, 1)
+            scale_weight_vals = np.zeros(scale_weight_shape, dtype=np.float32)
+            for c in range(scale_weight_vals.size):
+                if c not in indices_set:
+                    scale_weight_vals[0][c] = 1.0
+            scale_output = gs.Variable(name=f'{node.name}_scale_tmp0', dtype=updates.dtype)
+            scale_weight_constant = gs.Constant(name=f'{node.name}_scale_tmp1',
+                                                values=scale_weight_vals)
+            scale_node = gs.Node(op='Mul',
+                                 inputs=[data, scale_weight_constant],
+                                 outputs=[scale_output],
+                                 name=f'{node.name}_scale')
+            graph.nodes.append(scale_node)
+            node.op = 'Add'
+            node.inputs = [scale_output, conv_output]
+            node.attrs.clear()
+
+            graph.cleanup()
+
+    def test(self, input_shapes=None, num_indices=None, axes=None):
+        input_shapes = input_shapes or [(1, 5, 6, 7)]
+        assert isinstance(input_shapes, list) and len(input_shapes) == 1
+        input_shape_data = input_shapes[0]
+        num_indices = num_indices or 3
+        axes = axes or [1, 2, 3]
+        maxabsdiff = 0.0
+        for axis in axes:
+            attrs = dict(axis=axis)
+            input_shape_updates = list(input_shape_data)
+            input_shape_updates[axis] = num_indices
+            input_shape_updates = tuple(input_shape_updates)
+            var_input_shapes = [input_shape_data, input_shape_updates]
+            orig_graph = self.generate(var_input_shapes, attrs, num_indices)
+            orig_path = IndexSelectionOperator.save_gs_graph(orig_graph, run_shape_inference=True)
+            reconstructed_graph = gs.import_onnx(onnx.load(orig_path))
+            for node in reconstructed_graph.nodes:
+                self.reconstruct(node, reconstructed_graph)
+            reconstructed_graph.name = orig_graph.name.replace('_orig', '_reconstructed')
+            reconstructed_path = IndexSelectionOperator.save_gs_graph(reconstructed_graph,
+                                                                      run_shape_inference=True)
+            maxabsdiff_axis = self.run_comparison([orig_path, reconstructed_path],
+                                                  input_shapes=var_input_shapes)
+            maxabsdiff = max(maxabsdiff_axis, maxabsdiff)
+        return maxabsdiff
+
+
+def main():
+    op = ScatterElements()
+    op.test()
+
+
+if __name__ == '__main__':
+    main()

--- a/operators/op_reconstruction/SpaceToDepth.py
+++ b/operators/op_reconstruction/SpaceToDepth.py
@@ -1,0 +1,58 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2022 - 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#
+"""Reconstruction of a SpaceToDepth op."""
+
+from logging import info
+import numpy as np
+import onnx_graphsurgeon as gs
+
+from common.Operator import Operator
+
+
+class SpaceToDepth(Operator):
+    @classmethod
+    def reconstruct(cls, node, graph):
+        if cls.qualifies_for_reconstruction(node):
+            info(f'Reconstructing {node.op} node "{node.name}"...')
+            blocksize = node.attrs.get('blocksize', 1)
+            channels_in, height_in, width_in = node.inputs[0].shape[1:]
+            assert height_in % blocksize == 0
+            assert width_in % blocksize == 0
+            channels_out = channels_in * blocksize * blocksize
+            node.op = 'Conv'
+            node.attrs = dict(kernel_shape=(blocksize, blocksize), strides=(blocksize, blocksize))
+            weight_shape = (channels_out, channels_in, blocksize, blocksize)
+            weight_vals = np.zeros(weight_shape, dtype=np.float32)
+            stacked_kernels = weight_vals.reshape(channels_out,
+                                                  channels_in * blocksize * blocksize)
+            for block_idx in range(channels_out):
+                kernel_one_idx = block_idx // channels_in + (block_idx %
+                                                             channels_in) * blocksize * blocksize
+                stacked_kernels[block_idx][kernel_one_idx] = 1
+            weight_vals = stacked_kernels.reshape(weight_shape)
+            weight_constant = gs.Constant(name=f'{node.name}_tmp0', values=weight_vals)
+            node.inputs.append(weight_constant)
+
+    def test(self, input_shapes=None, blocksize=None):
+        input_shapes = input_shapes or [(1, 5, 768, 768)]
+        blocksize = blocksize or 4
+        attrs = dict(blocksize=blocksize)
+        return super().test(input_shapes, attrs=attrs)
+
+
+def main():
+    op = SpaceToDepth()
+    op.test()
+
+
+if __name__ == '__main__':
+    main()

--- a/operators/op_reconstruction/Where.py
+++ b/operators/op_reconstruction/Where.py
@@ -1,0 +1,149 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#
+"""Reconstruction of a Where op."""
+
+from logging import info
+import onnx
+import numpy as np
+import onnx_graphsurgeon as gs
+
+from common.IndexSelectionOperator import IndexSelectionOperator
+
+
+class Where(IndexSelectionOperator):
+    expected_num_inputs = 3
+
+    def generate(self, input_shapes, axis=0):
+        assert len(input_shapes) == 2
+        assert tuple(input_shapes[0]) == tuple(input_shapes[1])
+        input_shape = input_shapes[0]
+        dtype = np.float32
+        var_inputs = [
+            gs.Variable(name=self.new_tensor_name(), dtype=dtype, shape=input_shape)
+            for _ in input_shapes
+        ]
+        outputs = [gs.Variable(name=self.new_tensor_name(), dtype=dtype)]
+        condition_shape = [1] * 4
+        condition_shape[axis] = input_shape[axis]
+        condition_vals = np.random.choice(a=[False, True], size=condition_shape)
+        condition_constant = gs.Constant(name=self.new_tensor_name(), values=condition_vals)
+        node = gs.Node(op=self.op,
+                       inputs=[condition_constant] + var_inputs,
+                       outputs=outputs,
+                       name=self.new_node_name())
+        graph = gs.Graph(nodes=[node], inputs=var_inputs, outputs=node.outputs, name=node.name)
+        graph.name = f'{self.op}_axis{axis}_orig'
+        return graph
+
+    @staticmethod
+    def get_orig_axis(condition_shape, var_input_shape):
+        C, H, W = var_input_shape[1:]
+        condition_shape = tuple(condition_shape)
+        orig_axis = 0
+        if condition_shape == (1, C, 1, 1):
+            orig_axis = 1
+        elif condition_shape == (1, 1, H, 1):
+            orig_axis = 2
+        elif condition_shape == (1, 1, 1, W):
+            orig_axis = 3
+        return orig_axis
+
+    @staticmethod
+    def insert_transposes_if_needed(node, graph):
+        condition = node.inputs[0]
+        var_input_shape = node.inputs[1].shape
+        orig_axis = Where.get_orig_axis(condition.shape, var_input_shape)
+        assert orig_axis != 0, 'Got orig_axis == 0, this op should not have qualified for reconstruction in the first place'
+        transposes_needed = IndexSelectionOperator.insert_transposes_if_needed(
+            node, graph, orig_axis)
+        if transposes_needed:
+            if orig_axis == 2:
+                first_permute = (0, 2, 3, 1)
+            elif orig_axis == 3:
+                first_permute = (0, 3, 2, 1)
+            elif orig_axis == 1:
+                assert False, 'Should not have required to transpose'
+            else:
+                assert False, 'Not implemented'
+            condition.values = np.transpose(condition.values, first_permute)
+
+    @classmethod
+    def qualifies_for_reconstruction(cls, node):
+        result = node.op == cls.op_to_reconstruct()
+        if result:
+            result = result and len(node.inputs) == cls.expected_num_inputs
+            result = result and isinstance(node.inputs[0], gs.Constant)
+            result = result and not isinstance(node.inputs[1], gs.Constant) and len(
+                node.inputs[1].shape) == 4
+            result = result and not isinstance(node.inputs[2], gs.Constant) and len(
+                node.inputs[0].shape) == 4
+            result = result and tuple(node.inputs[1].shape) == tuple(node.inputs[2].shape)
+        if result:
+            condition_shape = node.inputs[0].shape
+            var_input_shape = node.inputs[1].shape
+            orig_axis = Where.get_orig_axis(condition_shape, var_input_shape)
+            result &= orig_axis in {1, 2, 3}
+        return result
+
+    @classmethod
+    def reconstruct(cls, node, graph):
+        if cls.qualifies_for_reconstruction(node):
+            info(f'Reconstructing {node.op} node "{node.name}"...')
+            Where.insert_transposes_if_needed(node, graph)
+            condition = node.inputs[0]
+            var_inputs = node.inputs[1:]
+            channels_out = var_inputs[0].shape[1]
+            channels_in = 2 * channels_out
+            dtype = var_inputs[0].dtype
+            concat_name = f'{node.name}_concat'
+            concat_out = gs.Variable(name=concat_name, dtype=dtype)
+            concat_node = gs.Node(op='Concat',
+                                  inputs=var_inputs,
+                                  outputs=[concat_out],
+                                  name=concat_name,
+                                  attrs=dict(axis=1))
+            graph.nodes.append(concat_node)
+            node.op = 'Conv'
+            weight_shape = (channels_out, channels_in, 1, 1)
+            weight_vals = np.zeros(weight_shape, dtype=np.float32)
+            for c_out, selector in enumerate(condition.values.flatten()):
+                selector_idx = 0 if selector else 1
+                weight_vals[c_out, selector_idx * channels_out + c_out, :, :] = 1
+            weight_constant = gs.Constant(name=f'{node.name}_tmp0', values=weight_vals)
+            node.inputs = [concat_out, weight_constant]
+            graph.cleanup()
+
+    def test(self, input_shapes=None, axes=None):
+        input_shapes = input_shapes or [(1, 3, 5, 7)] * 2
+        axes = axes or [1, 2, 3]
+        maxabsdiff = 0.0
+        for axis in axes:
+            orig_graph = self.generate(input_shapes, axis)
+            orig_path = IndexSelectionOperator.save_gs_graph(orig_graph, run_shape_inference=True)
+            reconstructed_graph = gs.import_onnx(onnx.load(orig_path))
+            for node in reconstructed_graph.nodes:
+                self.reconstruct(node, reconstructed_graph)
+            reconstructed_graph.name = orig_graph.name.replace('_orig', '_reconstructed')
+            reconstructed_path = IndexSelectionOperator.save_gs_graph(reconstructed_graph)
+            maxabsdiff_axis = self.run_comparison([orig_path, reconstructed_path],
+                                                  input_shapes=input_shapes)
+            maxabsdiff = max(maxabsdiff_axis, maxabsdiff)
+        return maxabsdiff
+
+
+def main():
+    op = Where()
+    op.test()
+
+
+if __name__ == '__main__':
+    main()

--- a/operators/op_reconstruction/Xor.py
+++ b/operators/op_reconstruction/Xor.py
@@ -1,0 +1,51 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#
+"""Reconstruction of a Xor op."""
+
+from logging import info
+import numpy as np
+import onnx_graphsurgeon as gs
+
+from common.BinaryOperator import BinaryOperator
+
+
+class Xor(BinaryOperator):
+    @classmethod
+    def reconstruct(cls, node, graph):
+        if cls.qualifies_for_reconstruction(node):
+            info(f'Reconstructing {node.op} node "{node.name}"...')
+            node.op = 'Sub'
+            for tensor in node.inputs + node.outputs:
+                tensor.dtype = np.float32
+            tmp_tensor = gs.Variable(name=f'{node.name}_tmp0', dtype=np.float32)
+            abs_node = gs.Node(op='Abs',
+                               inputs=[tmp_tensor],
+                               outputs=[node.outputs[0]],
+                               name=f'{node.name}_abs')
+            node.outputs = [tmp_tensor]
+            graph.nodes.append(abs_node)
+
+    def test(self):
+        input_shapes = [(1, 4, 1, 1)] * 2
+        input_data = list()
+        input_data.append(np.array([True, True, False, False]).reshape(input_shapes[0]))
+        input_data.append(np.array([True, False, True, False]).reshape(input_shapes[1]))
+        return super().test(input_data=input_data)
+
+
+def main():
+    op = Xor()
+    op.test()
+
+
+if __name__ == '__main__':
+    main()

--- a/operators/op_reconstruction/__init__.py
+++ b/operators/op_reconstruction/__init__.py
@@ -1,0 +1,29 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#
+"""Taken from https://julienharbulot.com/python-dynamical-import.html"""
+from inspect import isclass
+from pkgutil import iter_modules
+from pathlib import Path
+from importlib import import_module
+
+# iterate through the modules in the current package
+package_dir = Path(__file__).resolve().parent
+for (_, module_name, _) in iter_modules([package_dir]):
+
+    # import the module and iterate through its attributes
+    module = import_module(f"{__name__}.{module_name}")
+    for attribute_name in dir(module):
+        attribute = getattr(module, attribute_name)
+
+        if isclass(attribute):
+            # Add the class to this package's variables
+            globals()[attribute_name] = attribute

--- a/operators/registry.py
+++ b/operators/registry.py
@@ -1,0 +1,32 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2022 - 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#
+"""Registry for op reconstructions."""
+
+from op_reconstruction import *
+
+RECONSTRUCTOR_REGISTRY = [
+    Neg,
+    DepthToSpace,
+    SpaceToDepth,
+    Xor,
+    And,
+    Or,
+    Not,
+    Gather,
+    GRU,
+    ScatterElements,
+    Where
+]
+
+RECONSTRUCTOR_REGISTRY_DICT = dict()
+for reconstructor in RECONSTRUCTOR_REGISTRY:
+    RECONSTRUCTOR_REGISTRY_DICT[reconstructor.op_to_reconstruct()] = reconstructor

--- a/operators/test.py
+++ b/operators/test.py
@@ -1,0 +1,52 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2022 - 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#
+"""Simple testbench for all op reconstructions."""
+import logging
+from collections import defaultdict
+from registry import RECONSTRUCTOR_REGISTRY
+
+MAXABSDIFF_THRESHOLDS = defaultdict(lambda: 0.0)
+MAXABSDIFF_THRESHOLDS['GRU'] = 1e-6
+
+
+
+def log_results(passed_tests, failed_tests):
+    num_passed_tests = len(passed_tests)
+    num_failed_tests = len(failed_tests)
+    num_total_tests = num_passed_tests + num_failed_tests
+    passed_percentage = num_passed_tests * 100.0 / num_total_tests
+    logging.info(f'{len(passed_tests)}/{num_total_tests} ({passed_percentage}%) tests passed.')
+    logging.info(f'{num_passed_tests} passed tests: {passed_tests}')
+    logging.info(f'{num_failed_tests} failed tests: {failed_tests}')
+
+
+def test():
+    passed_tests = list()
+    failed_tests = list()
+    for reconstructor in RECONSTRUCTOR_REGISTRY:
+        op = reconstructor()
+        threshold = MAXABSDIFF_THRESHOLDS[op.op]
+        maxabsdiff = op.test()
+        if maxabsdiff <= threshold:
+            passed_tests.append(op.op)
+        else:
+            failed_tests.append(op.op)
+            logging.error(f'Test for {op.op} failed')
+    log_results(passed_tests, failed_tests)
+
+
+def main():
+    test()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/prepare_models/README.md
+++ b/scripts/prepare_models/README.md
@@ -1,11 +1,14 @@
 # Instructions to Download, Prepare & Run DLA Reference Models
+
 This page provides instructions for optimizing the performance of models running on DLA. 
 Make sure you install the Python dependencies from `requirements.txt`.
 
 Below steps were run with TensorRT 8.5 on an Orin L4T platform where `trtexec` was present in `/usr/local/tensorrt/bin/trtexec`.
 
 ## ResNet-50
+
 ### Download
+
 Original location: https://zenodo.org/record/4735647/files/resnet50_v1.onnx
 
 Mirror: https://web.archive.org/web/20221201211434/https://zenodo.org/record/4735647/files/resnet50_v1.onnx
@@ -13,6 +16,7 @@ Mirror: https://web.archive.org/web/20221201211434/https://zenodo.org/record/473
 Source: https://github.com/mlcommons/inference/blob/2acca351fbdf7821a5d8fa1d9a9799d50ab270f1/vision/classification_and_detection/README.md
 
 ### Prepare & Run
+
 1. Download `resnet50_v1.onnx` from above links
 2. Run `python3 resnet50.py` on any platform (host or Orin target)
 3. Copy the generated `resnet50_v1_prepared.onnx` to your Orin target
@@ -21,6 +25,7 @@ Source: https://github.com/mlcommons/inference/blob/2acca351fbdf7821a5d8fa1d9a97
 ## SSD-ResNet-34
 
 ### Download
+
 Original location: https://zenodo.org/record/3228411/files/resnet34-ssd1200.onnx
 
 Mirror: https://web.archive.org/web/20221201213043/https://zenodo.org/record/3228411/files/resnet34-ssd1200.onnx
@@ -28,15 +33,16 @@ Mirror: https://web.archive.org/web/20221201213043/https://zenodo.org/record/322
 Source: https://github.com/mlcommons/inference/blob/2acca351fbdf7821a5d8fa1d9a9799d50ab270f1/vision/classification_and_detection/README.md
 
 ### Prepare & Run
+
 1. Download `resnet34-ssd1200.onnx` from above links
 2. Run `python3 ssd_resnet34.py` on any platform (host or Orin target)
 3. Copy the generated `resnet34-ssd1200_prepared.onnx` to your Orin target
 4. Run the following command on your Orin target: `./trtexec --useDLACore=0 --int8 --memPoolSize=dlaSRAM:1MiB --inputIOFormats=int8:dla_hwc4 --outputIOFormats=int8:chw32 --onnx=dla/regression/testdb/resnet34-ssd1200_prepared.onnx`
 
-
 ## SSD-MobileNetV1
 
 ### Download
+
 Original location: https://zenodo.org/record/4735652/files/ssd_mobilenet_v1_coco_2018_01_28.onnx
 
 Mirror: https://web.archive.org/web/20221201212531/https://zenodo.org/record/4735652/files/ssd_mobilenet_v1_coco_2018_01_28.onnx
@@ -44,6 +50,7 @@ Mirror: https://web.archive.org/web/20221201212531/https://zenodo.org/record/473
 Source: https://github.com/mlcommons/inference/blob/2acca351fbdf7821a5d8fa1d9a9799d50ab270f1/vision/classification_and_detection/README.md
 
 ### Prepare & Run
+
 1. Download `ssd_mobilenet_v1_coco_2018_01_28.onnx` from above links
 2. Run `python3 ssd_mobilenetv1.py` on any platform (host or Orin target)
 3. Copy the generated `ssd_mobilenet_v1_coco_2018_01_28_prepared.onnx` to your Orin target

--- a/scripts/prepare_models/README.md
+++ b/scripts/prepare_models/README.md
@@ -1,6 +1,6 @@
 # Instructions to Download, Prepare & Run DLA Reference Models
 
-This page provides instructions for optimizing the performance of models running on DLA. 
+This page provides instructions for optimizing the performance of models running on DLA.
 Make sure you install the Python dependencies from `requirements.txt`.
 
 Below steps were run with TensorRT 8.5 on an Orin L4T platform where `trtexec` was present in `/usr/local/tensorrt/bin/trtexec`.
@@ -37,7 +37,7 @@ Source: https://github.com/mlcommons/inference/blob/2acca351fbdf7821a5d8fa1d9a97
 1. Download `resnet34-ssd1200.onnx` from above links
 2. Run `python3 ssd_resnet34.py` on any platform (host or Orin target)
 3. Copy the generated `resnet34-ssd1200_prepared.onnx` to your Orin target
-4. Run the following command on your Orin target: `./trtexec --useDLACore=0 --int8 --memPoolSize=dlaSRAM:1MiB --inputIOFormats=int8:dla_hwc4 --outputIOFormats=int8:chw32 --onnx=dla/regression/testdb/resnet34-ssd1200_prepared.onnx`
+4. Run the following command on your Orin target: `./trtexec --useDLACore=0 --int8 --memPoolSize=dlaSRAM:1MiB --inputIOFormats=int8:dla_hwc4 --outputIOFormats=int8:chw32 --onnx=resnet34-ssd1200_prepared.onnx`
 
 ## SSD-MobileNetV1
 


### PR DESCRIPTION
Scripts to reconstruct the following ONNX ops into DLA-supported ops:
Neg,
DepthToSpace,
SpaceToDepth,
Xor,
And,
Or,
Not,
Gather,
GRU,
ScatterElements,
Where

Also add README about the level of DLA support for various ONNX operators.