### PR TITLE
Update to DLA 3.14.0

### DIFF
--- a/FAQ/README.md
+++ b/FAQ/README.md
@@ -129,5 +129,8 @@ ISAAC SDK has a reference application for proximity segmentation using stereo da
 ### What does "CBUF validation" mean if I try to run a Convolution on DLA through TensorRT?
 DLA has an internal SRAM called CBUF (short for Convolution Buffer). As of TensorRT 8.6.0, before TensorRT hands over a Convolution node mapped to DLA to the DLA Compiler, it performs a heuristic-based check if that node can store its data and weights in CBUF.
 
+### Are inputs in kDLA_HWC4 format supported if consumed by a Convolution whose compute precision differs from the inputs'?
+No, such configurations where FP16 `kDLA_HWC4` inputs are consumed by an INT8 Conv or vice versa are not yet supported. You will need to update the Conv layer's precision to the input's precision.
+
 ### I am running into an issue on my DLA, what do I do?
 First, try to update to the latest JetPack / DRIVE release if you can and check if the issue still occurs. Please refer to the [NVIDIA Forums](https://forums.developer.nvidia.com/) to see if other community members have managed to solve the issue and share your problem. 

--- a/operators/README.md
+++ b/operators/README.md
@@ -41,13 +41,13 @@ If you are interested in a specific DLA operator to be enabled in TensorRT, feel
 | BatchNormalization        | Native          | Native | See **Scale layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | Ceil                      | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | Celu                      | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
-| Clip                      | Native          | Native |  See **Activation layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/indexhtml#dla-lay-supp-rest)                                                                                      |
+| Clip                      | Native          | Native |  See **Activation layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)                                                                                      |
 | Concat                    | Native          | Native | See **Concatenation layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | Constant                  | Native          | [See RFE](#request-for-enhancements-rfe) | TensorRT performs constant folding into supported DLA ops. You may need to allow GPU fallback to trigger the folding but the final operator would only run on DLA.
 | ConstantOfShape           | Can be inferred at build time          | Can be inferred at build time  |
 | Conv                      | Native          | Native | See **Convolution and Fully Connected layers** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | ConvTranspose             | Native          | Native | See **Deconvolution layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
-| Cos                       | Native          | Native (as of DLA 3.14.0) |
+| Cos                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | Cosh                      | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | CumSum                       | Reconstruction          | Reconstruction | With `axis=1`, it can be expressed through a 1x1 Conv
 | DepthToSpace              | Reconstruction          | Native (as of DLA 3.14.0) | See [op_reconstruction/DepthToSpace.py](op_reconstruction/DepthToSpace.py)

--- a/operators/README.md
+++ b/operators/README.md
@@ -2,7 +2,7 @@
 
 # Supported ONNX Operators & Functions on Orin DLA
 
-DLA operator functionality is exposed through the TensorRT builder, which internally links to DLA SW libraries (see [DLA Workflow](https://developer.nvidia.com/deep-learning-accelerator)). While some ONNX operator or functions may already be available in DLA SW, TensorRT may not expose them yet.
+DLA operator functionality is exposed through the TensorRT builder, which internally links to DLA SW libraries (see [DLA Workflow](https://developer.nvidia.com/deep-learning-accelerator)). While some ONNX operators or functions may already be available in DLA SW, TensorRT may not expose them yet.
 See below for the support matrix of ONNX operators & functions on Orin DLA. If you are interested in a specific DLA operator that is not supported through TensorRT yet, feel free to raise a [GitHub Issue](https://github.com/NVIDIA/Deep-Learning-Accelerator-SW/issues) and/or inform your NVIDIA representative (in particular for NVIDIA DRIVE customers).
 
 See [General Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest) that apply to all operations below. Many of those ops are supported on Xavier DLA as well, see [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest).

--- a/operators/README.md
+++ b/operators/README.md
@@ -1,13 +1,13 @@
 <!--- SPDX-License-Identifier: Apache-2.0 -->
 
-# Supported ONNX Operators on Orin DLA
+# Supported ONNX Operators & Functions on Orin DLA
 
-DLA operator functionality is exposed through the TensorRT builder, which internally links to DLA SW libraries (see [DLA Workflow](https://developer.nvidia.com/deep-learning-accelerator)). While some operators may already be available in DLA SW, TensorRT may not expose them yet.
-See below for the support matrix of ONNX operators on Orin DLA. If you are interested in a specific DLA operator that is not supported through TensorRT yet, feel free to raise a [GitHub Issue](https://github.com/NVIDIA/Deep-Learning-Accelerator-SW/issues) and/or inform your NVIDIA representative (in particular for NVIDIA DRIVE customers).
+DLA operator functionality is exposed through the TensorRT builder, which internally links to DLA SW libraries (see [DLA Workflow](https://developer.nvidia.com/deep-learning-accelerator)). While some ONNX operator or functions may already be available in DLA SW, TensorRT may not expose them yet.
+See below for the support matrix of ONNX operators & functions on Orin DLA. If you are interested in a specific DLA operator that is not supported through TensorRT yet, feel free to raise a [GitHub Issue](https://github.com/NVIDIA/Deep-Learning-Accelerator-SW/issues) and/or inform your NVIDIA representative (in particular for NVIDIA DRIVE customers).
 
-See [General Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest) that apply to all operators. Many of those operators are supported on Xavier DLA as well, see [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest).
+See [General Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest) that apply to all operations below. Many of those ops are supported on Xavier DLA as well, see [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest).
 
-TensorRT 8.5 supports operators up to Opset 17. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/master/docs/Operators.md).
+TensorRT 8.6 supports operators up to Opset 17. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/master/docs/Operators.md).
 
 Note that the scripts in `op_reconstruction/` are intended as a recipe for how ops currently not supported on DLA can be decomposed into supported ops. Depending on your setup, you may choose to perform such op reconstructions in the ONNX domain post-training (as done here) or during the training process (for example in TensorFlow or PyTorch).
 
@@ -17,92 +17,118 @@ Below Operator Support Matrix requires the following minimum system config (the 
 | ----------------- | ---------------- | -------------- | ---------------- |
 | DRIVE Orin (Automotive)        | DRIVE OS 6.0.6.0 | DLA 3.12.0     | TensorRT 8.5.10  |
 | Jetson Orin (Embedded)      | JetPack 5.1.1    | DLA 3.12.1     | TensorRT 8.5.2   |
+| DRIVE Orin (Automotive)        | DRIVE OS 6.0.7.0 | DLA 3.13.0     | TensorRT 8.6.10  |
+| DRIVE Orin (Automotive)        | DRIVE OS 6.0.8.0 | DLA 3.14.0     | TensorRT 8.6.11  |
 
 ## Request for enhancements (RFE)
 
 If you are interested in a specific DLA operator to be enabled in TensorRT, feel free to raise a [GitHub Issue](https://github.com/NVIDIA/TensorRT/issues) and/or inform your NVIDIA representative (in particular for NVIDIA DRIVE customers).
 
-## Operator Support Matrix
+## ONNX Operator/Function Support Matrix
 
-| Operator                  | Orin DLA support through TensorRT | Orin DLA support through DLA SW   | Restrictions                                                                                                           |
+| Operator/Function         | Orin DLA support through TensorRT | Orin DLA support through DLA SW   | Restrictions                                                                                                           |
 |---------------------------|--------------------------|--------------------------|------------------------------------------------------------------------------------------------------------------------|
 | Abs                       | Native                   | Native | See **Unary layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
-| Acos                      | [See RFE](#request-for-enhancements-rfe)                   | Planned in future release |
-| Acosh                     | [See RFE](#request-for-enhancements-rfe)          | Planned in future release  |
+| Acos                      | [See RFE](#request-for-enhancements-rfe)                   | Native (as of DLA 3.14.0) |
+| Acosh                     | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0)  |
 | Add                       | Native                   | Native | See **Scale layer** and **ElementWise Layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | And                       | Reconstruction          | Reconstruction | See [op_reconstruction/And.py](op_reconstruction/And.py)
-| Asin                      | [See RFE](#request-for-enhancements-rfe)          | Planned in future release  |
-| Asinh                     | [See RFE](#request-for-enhancements-rfe)          | Planned in future release  |
-| Atan                      | [See RFE](#request-for-enhancements-rfe)          | Planned in future release  |
-| Atanh                     | [See RFE](#request-for-enhancements-rfe)          | Planned in future release  |
+| Asin                      | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0)  |
+| Asinh                     | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0)  |
+| Atan                      | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0)  |
+| Atanh                     | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0)  |
 | AveragePool               | Native        | Native | See **Pooling layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)                                                                                                           |
 | BatchNormalization        | Native          | Native | See **Scale layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
-| Celu                      | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
+| Ceil                      | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| Celu                      | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | Clip                      | Native          | Native |  See **Activation layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/indexhtml#dla-lay-supp-rest)                                                                                      |
 | Concat                    | Native          | Native | See **Concatenation layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
-| Constant                  | Native          | Native | TensorRT performs constant folding into supported DLA ops.
+| Constant                  | Native          | Native | TensorRT performs constant folding into supported DLA ops. You may need to allow GPU fallback to trigger the folding but the final operator would only run on DLA.
 | ConstantOfShape           | Can be inferred at build time          | Can be inferred at build time  |
 | Conv                      | Native          | Native | See **Convolution and Fully Connected layers** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | ConvTranspose             | Native          | Native | See **Deconvolution layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
-| Cos                       | Native          | Planned in future release|
-| Cosh                      | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
-| DepthToSpace              | Reconstruction          | Reconstruction | See [op_reconstruction/DepthToSpace.py](op_reconstruction/DepthToSpace.py)
-| Div                       | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
-| Elu                       | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
+| Cos                       | Native          | Native (as of DLA 3.14.0) |
+| Cosh                      | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| CumSum                       | Reconstruction          | Reconstruction | With `axis=1`, it can be expressed with a 1x1 Conv
+| DepthToSpace              | Reconstruction          | Native (as of DLA 3.14.0) | See [op_reconstruction/DepthToSpace.py](op_reconstruction/DepthToSpace.py)
+| Div                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| Elu                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | Equal                     | Native         | Native | See **Equal operation** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
-| Erf                       | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
-| Exp                       | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
+| Erf                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| Exp                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| Expand                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| Floor                       | [See RFE](#request-for-enhancements-rfe)        | Native (as of DLA 3.14.0) |
 | Gather                    | Reconstruction          | Reconstruction | See [op_reconstruction/Gather.py](op_reconstruction/Gather.py)
 | Gemm                      | Native          | Native | See **Convolution and Fully Connected layers** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | GlobalAveragePool         | [See RFE](#request-for-enhancements-rfe)          | Native |
+| GlobalLpPool             | [See RFE](#request-for-enhancements-rfe)          |  Native (as of DLA 3.14.0) |
 | GlobalMaxPool             | [See RFE](#request-for-enhancements-rfe)          | Native |
-| Greater                   | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
-| GreaterOrEqual            | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
+| Greater                   | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| GreaterOrEqual            | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| GroupNormalization            | [See RFE](#request-for-enhancements-rfe)      | Reconstruction (as of DLA 3.14.0) | Can be expressed with ReduceMean, Sub, Pow, Add, Sqrt, Div, Mul
 | GRU                       | Reconstruction          | Reconstruction | See [op_reconstruction/GRU.py](op_reconstruction/GRU.py)
-| HardSwish                 | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
-| HardSigmoid               | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
+| HardSigmoid               | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| HardSwish                 | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| Identity                 | Reconstruction | Native (as of DLA 3.14.0) | Can be expressed with Transpose and `perm=(0, 1, 2, 3)` for example
+| InstanceNormalization            | [See RFE](#request-for-enhancements-rfe)      | Reconstruction (as of DLA 3.14.0) | Can be expressed with ReduceMean, Sub, Pow, Add, Sqrt, Div, Mul
+| LayerNormalization            | [See RFE](#request-for-enhancements-rfe)      | Reconstruction (as of DLA 3.14.0) | Can be expressed with ReduceMean, Sub, Pow, Add, Sqrt, Div, Mul
 | LeakyRelu                 | Native          | Native | See **Activation layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
-| Less                      | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
-| LessOrEqual               | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
-| Log                       | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
-| LogSoftmax                | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
+| Less                      | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| LessOrEqual               | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| Log                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| LogSoftmax                       | [See RFE](#request-for-enhancements-rfe)          | Reconstruction (as of DLA 3.14.0) | Can be expressed with Log and Softmax
+| LpNormalization                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| LpPool                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | LRN                       | Native          | Native | See **LRN (Local Response Normalization) layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | MatMul                    | Native          | Native | The second input must be a constant, also see **Convolution and Fully Connected layers** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | Max                       | Native          | Native| See **ElementWise layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | MaxPool                   | Native          | Native| See **Pooling layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
-| Min                       | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
-| Mod                       | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
+| Mean                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| Min                       | [See RFE](#request-for-enhancements-rfe)          | Native |
+| Mish                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| Mod                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| MeanVarianceNormalization            | [See RFE](#request-for-enhancements-rfe)      | Reconstruction (as of DLA 3.14.0) | Can be expressed with ReduceMean, Sub, Pow, Add, Sqrt, Div, Mul
 | Mul                       | Native          | Native | See **Scale layer** and **ElementWise layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | Neg                       | Reconstruction          | Reconstruction |  See [op_reconstruction/Neg.py](op_reconstruction/Neg.py)
 | Not                       | Reconstruction          | Reconstruction | See [op_reconstruction/Not.py](op_reconstruction/Not.py)
 | Or                        | Reconstruction          | Reconstruction | See [op_reconstruction/Or.py](op_reconstruction/Or.py)
-| Pow                       | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
+| Pad                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| Pow                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | PRelu                     | Native          | Native | See **Parametric ReLU layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
-| Reciprocal                | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
+| Reciprocal                | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | ReduceMax                 | [See RFE](#request-for-enhancements-rfe)          | Native|
 | ReduceMean                | [See RFE](#request-for-enhancements-rfe)          | Native|
 | ReduceMin                 | [See RFE](#request-for-enhancements-rfe)          | Native|
+| ReduceL1                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| ReduceL2                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| ReduceSum                | [See RFE](#request-for-enhancements-rfe)          |  Native (as of DLA 3.14.0) |
+| ReduceSumSquare                | [See RFE](#request-for-enhancements-rfe)          |  Native (as of DLA 3.14.0) |
 | Relu                      | Native          | Native | See **Activation layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | Reshape                   | Native          | Native | See **Shuffle layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | Resize                    | Native         | Native | See **Resize layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)   |
+| Round                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | ScatterElements           | Reconstruction          | Reconstruction | See [op_reconstruction/ScatterElements.py](op_reconstruction/ScatterElements.py)
+| Selu                      | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | Shape                     |Can be inferred at build time          | Can be inferred at build time  |
+| Shrink                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | Sigmoid                   | Native          | Native | See **Activation layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
-| Sign                      | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
-| Sin                       | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
-| Sinh                      | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
+| Sign                      | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| Sin                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| Sinh                      | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | Slice                     | Native         | Native | See **Slice layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)                                                                                                |
 | Softmax                   | Native         | Native | See **SoftMax layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
-| Softplus                  | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
-| Softsign                  | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
-| SpaceToDepth              | Reconstruction          | Reconstruction | See [op_reconstruction/SpaceToDepth.py](op_reconstruction/SpaceToDepth.py)
-| Sqrt                      | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
+| Softplus                  | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| Softsign                  | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| SpaceToDepth              | Reconstruction          | Native (as of DLA 3.14.0) | See [op_reconstruction/SpaceToDepth.py](op_reconstruction/SpaceToDepth.py)
+| Split                     | Native         | Native | Translated to Slice inside TensorRT's ONNX parser. See **Slice layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| Sqrt                      | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | Sub                       | Native         | Native | See **ElementWise layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | Sum                       | Native         | Native | See **ElementWise layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
-| Tan                       | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
+| Tan                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | Tanh                      | Native         | Native | See **Activation layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
-| ThresholdedRelu           | [See RFE](#request-for-enhancements-rfe)          | Planned in future release |
+| ThresholdedRelu           | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | Transpose                 | Native         | Native | See **Shuffle layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| Tile                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | Upsample                  | Native         | Native | See **Resize layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | Where                     | Reconstruction          | Reconstruction | See [op_reconstruction/Where.py](op_reconstruction/Where.py)
 | Xor                       | Reconstruction          | Reconstruction | See [op_reconstruction/Xor.py](op_reconstruction/Xor.py)

--- a/operators/README.md
+++ b/operators/README.md
@@ -9,7 +9,7 @@ See [General Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/develop
 
 TensorRT 8.6 supports operators up to Opset 17. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/master/docs/Operators.md).
 
-Note that the scripts in `op_reconstruction/` are intended as a recipe for how ops currently not supported on DLA can be decomposed into supported ops. Depending on your setup, you may choose to perform such op reconstructions in the ONNX domain post-training (as done here) or during the training process (for example in TensorFlow or PyTorch).
+Note that the scripts in `op_reconstruction/` are intended as a recipe for how ops currently not supported on DLA can be decomposed into supported ops. Depending on your setup, you may choose to perform such op reconstructions in the ONNX domain post-training (as done here) or during the training process (for example in TensorFlow or PyTorch). The case of "Native" in the DLA SW support column and "Reconstruction" in the TensorRT support column indicates that an op can be supported through TensorRT by decomposing it into other DLA ops already supported by TensorRT.
 
 Below Operator Support Matrix requires the following minimum system config (the OS by default gets shipped with the DLA SW and TensorRT versions to its right):
 

--- a/operators/README.md
+++ b/operators/README.md
@@ -43,23 +43,27 @@ If you are interested in a specific DLA operator to be enabled in TensorRT, feel
 | Celu                      | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | Clip                      | Native          | Native |  See **Activation layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/indexhtml#dla-lay-supp-rest)                                                                                      |
 | Concat                    | Native          | Native | See **Concatenation layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
-| Constant                  | Native          | Native | TensorRT performs constant folding into supported DLA ops. You may need to allow GPU fallback to trigger the folding but the final operator would only run on DLA.
+| Constant                  | Native          | [See RFE](#request-for-enhancements-rfe) | TensorRT performs constant folding into supported DLA ops. You may need to allow GPU fallback to trigger the folding but the final operator would only run on DLA.
 | ConstantOfShape           | Can be inferred at build time          | Can be inferred at build time  |
 | Conv                      | Native          | Native | See **Convolution and Fully Connected layers** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | ConvTranspose             | Native          | Native | See **Deconvolution layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | Cos                       | Native          | Native (as of DLA 3.14.0) |
 | Cosh                      | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
-| CumSum                       | Reconstruction          | Reconstruction | With `axis=1`, it can be expressed with a 1x1 Conv
+| CumSum                       | Reconstruction          | Reconstruction | With `axis=1`, it can be expressed through a 1x1 Conv
 | DepthToSpace              | Reconstruction          | Native (as of DLA 3.14.0) | See [op_reconstruction/DepthToSpace.py](op_reconstruction/DepthToSpace.py)
+| DequantizeLinear          | Reconstruction          | Reconstruction | Can be collapsed to INT8 scaling factor, switching from explicit to implicit quantization
 | Div                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | Elu                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | Equal                     | Native         | Native | See **Equal operation** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | Erf                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | Exp                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | Expand                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| Flatten                       | [See RFE](#request-for-enhancements-rfe)          | [See RFE](#request-for-enhancements-rfe) |
 | Floor                       | [See RFE](#request-for-enhancements-rfe)        | Native (as of DLA 3.14.0) |
 | Gather                    | Reconstruction          | Reconstruction | See [op_reconstruction/Gather.py](op_reconstruction/Gather.py)
-| Gemm                      | Native          | Native | See **Convolution and Fully Connected layers** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| GatherElements                    | Reconstruction          | Reconstruction | See [op_reconstruction/Gather.py](op_reconstruction/Gather.py) which works similarly
+| GatherND                    | Reconstruction          | Reconstruction | See [op_reconstruction/Gather.py](op_reconstruction/Gather.py) which works similarly
+| Gemm                      | Native          | [See RFE](#request-for-enhancements-rfe) | The second input must be a constant, also see **Convolution and Fully Connected layers** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest). TensorRT can translate this to a 1x1 Conv internally.
 | GlobalAveragePool         | [See RFE](#request-for-enhancements-rfe)          | Native |
 | GlobalLpPool             | [See RFE](#request-for-enhancements-rfe)          |  Native (as of DLA 3.14.0) |
 | GlobalMaxPool             | [See RFE](#request-for-enhancements-rfe)          | Native |
@@ -69,7 +73,7 @@ If you are interested in a specific DLA operator to be enabled in TensorRT, feel
 | GRU                       | Reconstruction          | Reconstruction | See [op_reconstruction/GRU.py](op_reconstruction/GRU.py)
 | HardSigmoid               | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | HardSwish                 | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
-| Identity                 | Reconstruction | Native (as of DLA 3.14.0) | Can be expressed with Transpose and `perm=(0, 1, 2, 3)` for example
+| Identity                 | Reconstruction | Native (as of DLA 3.14.0) | Can be expressed with identity BatchNormalization (TensorRT Scale layer) for example
 | InstanceNormalization            | [See RFE](#request-for-enhancements-rfe)      | Reconstruction (as of DLA 3.14.0) | Can be expressed with ReduceMean, Sub, Pow, Add, Sqrt, Div, Mul
 | LayerNormalization            | [See RFE](#request-for-enhancements-rfe)      | Reconstruction (as of DLA 3.14.0) | Can be expressed with ReduceMean, Sub, Pow, Add, Sqrt, Div, Mul
 | LeakyRelu                 | Native          | Native | See **Activation layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
@@ -80,7 +84,8 @@ If you are interested in a specific DLA operator to be enabled in TensorRT, feel
 | LpNormalization                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | LpPool                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | LRN                       | Native          | Native | See **LRN (Local Response Normalization) layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
-| MatMul                    | Native          | Native | The second input must be a constant, also see **Convolution and Fully Connected layers** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| LSTM                       | Reconstruction          | Reconstruction | Can be unrolled similarly to [op_reconstruction/GRU.py](op_reconstruction/GRU.py)
+| MatMul                    | Native          | [See RFE](#request-for-enhancements-rfe) | The second input must be a constant, also see **Convolution and Fully Connected layers** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest). TensorRT can translate this to a 1x1 Conv internally.
 | Max                       | Native          | Native| See **ElementWise layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | MaxPool                   | Native          | Native| See **Pooling layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | Mean                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
@@ -95,19 +100,24 @@ If you are interested in a specific DLA operator to be enabled in TensorRT, feel
 | Pad                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | Pow                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | PRelu                     | Native          | Native | See **Parametric ReLU layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
+| QuantizeLinear          | Reconstruction          | Reconstruction | Can be collapsed to INT8 scaling factor, switching from explicit to implicit quantization	
 | Reciprocal                | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
-| ReduceMax                 | [See RFE](#request-for-enhancements-rfe)          | Native|
-| ReduceMean                | [See RFE](#request-for-enhancements-rfe)          | Native|
+| ReduceMax                 | Reconstruction          | Native| Can be reconstructied by decomposing into several MaxPool nodes
+| ReduceMean                | [See RFE](#request-for-enhancements-rfe)          | Native| Can be reconstructied by decomposing into several AveragePool or Conv nodes
 | ReduceMin                 | [See RFE](#request-for-enhancements-rfe)          | Native|
+| ReduceLogSum                       | [See RFE](#request-for-enhancements-rfe)          | Reconstruction (as of DLA 3.14.0) | Can be expressed with Log, ReduceSum and Exp
+| ReduceLogSumExp                       | [See RFE](#request-for-enhancements-rfe)          | Reconstruction (as of DLA 3.14.0) | Can be expressed with ReduceSum and Log
 | ReduceL1                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | ReduceL2                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
-| ReduceSum                | [See RFE](#request-for-enhancements-rfe)          |  Native (as of DLA 3.14.0) |
+| ReduceSum                | Reconstruction          |  Native (as of DLA 3.14.0) | Can be reconstructied by decomposing into Conv nodes or several AveragePool nodes while re-scaling with for example BatchNormalization (TensorRT Scale layer)
 | ReduceSumSquare                | [See RFE](#request-for-enhancements-rfe)          |  Native (as of DLA 3.14.0) |
 | Relu                      | Native          | Native | See **Activation layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | Reshape                   | Native          | Native | See **Shuffle layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | Resize                    | Native         | Native | See **Resize layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)   |
+| RNN                       | Reconstruction          | Reconstruction | Can be unrolled similarly to [op_reconstruction/GRU.py](op_reconstruction/GRU.py)
 | Round                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
-| ScatterElements           | Reconstruction          | Reconstruction | See [op_reconstruction/ScatterElements.py](op_reconstruction/ScatterElements.py)
+| Scatter                    | Reconstruction          | Reconstruction | See [op_reconstruction/ScatterElements.py](op_reconstruction/ScatterElements.py)
+| ScatterElements           | Reconstruction          | Reconstruction | See [op_reconstruction/ScatterElements.py](op_reconstruction/ScatterElements.py) which works similarly
 | Selu                      | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | Shape                     |Can be inferred at build time          | Can be inferred at build time  |
 | Shrink                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
@@ -122,6 +132,7 @@ If you are interested in a specific DLA operator to be enabled in TensorRT, feel
 | SpaceToDepth              | Reconstruction          | Native (as of DLA 3.14.0) | See [op_reconstruction/SpaceToDepth.py](op_reconstruction/SpaceToDepth.py)
 | Split                     | Native         | Native | Translated to Slice inside TensorRT's ONNX parser. See **Slice layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | Sqrt                      | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| Squeeze                       | [See RFE](#request-for-enhancements-rfe)          | [See RFE](#request-for-enhancements-rfe) |
 | Sub                       | Native         | Native | See **ElementWise layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | Sum                       | Native         | Native | See **ElementWise layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | Tan                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
@@ -129,6 +140,7 @@ If you are interested in a specific DLA operator to be enabled in TensorRT, feel
 | ThresholdedRelu           | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
 | Transpose                 | Native         | Native | See **Shuffle layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | Tile                       | [See RFE](#request-for-enhancements-rfe)          | Native (as of DLA 3.14.0) |
+| Unsqueeze                       | [See RFE](#request-for-enhancements-rfe)          | [See RFE](#request-for-enhancements-rfe) |
 | Upsample                  | Native         | Native | See **Resize layer** in [Layer Support and Restrictions](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#dla-lay-supp-rest)
 | Where                     | Reconstruction          | Reconstruction | See [op_reconstruction/Where.py](op_reconstruction/Where.py)
 | Xor                       | Reconstruction          | Reconstruction | See [op_reconstruction/Xor.py](op_reconstruction/Xor.py)

--- a/scripts/prepare_models/README.md
+++ b/scripts/prepare_models/README.md
@@ -89,8 +89,8 @@ Source: https://github.com/mlcommons/inference/blob/2acca351fbdf7821a5d8fa1d9a97
 ### Download
 
 - Original locations: 
-    - Full model: https://zenodo.org/record/7824202/files/retinanet_rn34_1280x768_dummy.onnx
-    - Backbone without RetinaNet head: https://zenodo.org/record/7824202/files/backbone_rn34_1280x768_dummy.onnx
+    - Full model: https://zenodo.org/record/8144349/files/retinanet_rn34_1280x768_dummy.onnx
+    - Backbone without RetinaNet head: https://zenodo.org/record/8144349/files/backbone_rn34_1280x768_dummy.onnx
 - Source: See "Structured Sparsity Case Study: Object Detection Accuracy with RetinaNet ResNet-34" in `../../README.md`. Note that the parameters are random due to dataset licensing restrictions (hence the `_dummy` appendix).
 
 ### Prepare & Run


### PR DESCRIPTION
- valid as of DLA 3.14.0 @ DRIVE OS 6.0.8.0
- fix links for RetinaNet ResNet-34 downloads
- add a few clarifications and fix some typos